### PR TITLE
feat(payroll): selective bulk settlement and dialog navigation fix

### DIFF
--- a/app/dashboard/payroll/actions.ts
+++ b/app/dashboard/payroll/actions.ts
@@ -780,27 +780,55 @@ export async function settlePayroll(payrollId: string) {
     return { success: true };
 }
 
-export async function settleAllDraftPayrolls() {
+class SettleDraftPayrollsValidationError extends Error {
+    readonly code: "NOT_FOUND" | "NOT_DRAFT";
+
+    constructor(code: "NOT_FOUND" | "NOT_DRAFT") {
+        super(code);
+        this.code = code;
+        this.name = "SettleDraftPayrollsValidationError";
+    }
+}
+
+export async function settleDraftPayrolls(payrollIds: string[]) {
     await requirePermission("Payroll", "update");
+
+    const uniqueIds = Array.from(new Set(payrollIds));
+    if (uniqueIds.length === 0) {
+        return { error: "Select at least one payroll to settle" };
+    }
 
     const now = new Date();
 
     let settledPayrollIds: string[] = [];
     try {
         settledPayrollIds = await db.transaction(async (tx) => {
-            const drafts = await tx
+            const rows = await tx
                 .select()
                 .from(payrollTable)
-                .where(eq(payrollTable.status, "draft"));
+                .where(inArray(payrollTable.id, uniqueIds));
 
-            for (const payroll of drafts) {
-                await settlePayrollInTx(tx, payroll, now);
+            if (rows.length !== uniqueIds.length) {
+                throw new SettleDraftPayrollsValidationError("NOT_FOUND");
+            }
+            if (rows.some((r) => r.status !== "draft")) {
+                throw new SettleDraftPayrollsValidationError("NOT_DRAFT");
             }
 
-            return drafts.map((p) => p.id);
+            const sorted = [...rows].sort((a, b) => a.id.localeCompare(b.id));
+            for (const payroll of sorted) {
+                await settlePayrollInTx(tx, payroll, now);
+            }
+            return sorted.map((p) => p.id);
         });
     } catch (error) {
-        console.error("Error settling all draft payrolls", error);
+        if (error instanceof SettleDraftPayrollsValidationError) {
+            if (error.code === "NOT_FOUND") {
+                return { error: "One or more payrolls were not found" };
+            }
+            return { error: "One or more payrolls are not drafts" };
+        }
+        console.error("Error settling draft payrolls", error);
         return { error: "Failed to settle draft payrolls" };
     }
 

--- a/app/dashboard/payroll/download-payrolls-button.tsx
+++ b/app/dashboard/payroll/download-payrolls-button.tsx
@@ -4,6 +4,7 @@ import * as React from "react";
 import type { ColumnDef } from "@tanstack/react-table";
 import type { RowSelectionState } from "@tanstack/react-table";
 import { Download } from "lucide-react";
+import { usePathname } from "next/navigation";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -55,6 +56,7 @@ function getDownloadFilenameFromContentDisposition(
 }
 
 export function DownloadPayrollsButton() {
+    const pathname = usePathname();
     const [open, setOpen] = React.useState(false);
     const [downloading, setDownloading] = React.useState(false);
     const [error, setError] = React.useState<string | null>(null);
@@ -67,6 +69,32 @@ export function DownloadPayrollsButton() {
     const selectedCount = Object.keys(rowSelection).filter(
         (k) => rowSelection[k],
     ).length;
+
+    const resetDownloadDialogUi = React.useCallback(() => {
+        setError(null);
+        setLoading(false);
+    }, []);
+
+    const wasDownloadDialogOpen = React.useRef(false);
+    const downloadDialogOpenedAtPath = React.useRef<string | null>(null);
+
+    React.useEffect(() => {
+        if (open && !wasDownloadDialogOpen.current) {
+            downloadDialogOpenedAtPath.current = pathname;
+        }
+        if (!open) {
+            downloadDialogOpenedAtPath.current = null;
+        }
+        wasDownloadDialogOpen.current = open;
+    }, [open, pathname]);
+
+    React.useEffect(() => {
+        if (!open || downloadDialogOpenedAtPath.current === null) return;
+        if (pathname !== downloadDialogOpenedAtPath.current) {
+            setOpen(false);
+            resetDownloadDialogUi();
+        }
+    }, [pathname, open, resetDownloadDialogUi]);
 
     React.useEffect(() => {
         let cancelled = false;
@@ -125,6 +153,7 @@ export function DownloadPayrollsButton() {
             a.remove();
             URL.revokeObjectURL(url);
             setOpen(false);
+            resetDownloadDialogUi();
         } catch (e) {
             console.error(e);
             setError("Failed to download payroll PDFs");
@@ -139,8 +168,7 @@ export function DownloadPayrollsButton() {
             onOpenChange={(nextOpen) => {
                 setOpen(nextOpen);
                 if (!nextOpen) {
-                    setError(null);
-                    setLoading(false);
+                    resetDownloadDialogUi();
                 }
             }}>
             <DialogTrigger asChild>

--- a/app/dashboard/payroll/settle-all-drafts-button.tsx
+++ b/app/dashboard/payroll/settle-all-drafts-button.tsx
@@ -1,7 +1,9 @@
 "use client";
 
 import * as React from "react";
-import { useRouter } from "next/navigation";
+import type { ColumnDef } from "@tanstack/react-table";
+import type { RowSelectionState } from "@tanstack/react-table";
+import { usePathname, useRouter } from "next/navigation";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -14,15 +16,24 @@ import {
     DialogTitle,
     DialogTrigger,
 } from "@/components/ui/dialog";
+import { createRowSelectionColumn } from "@/components/data-table/column-builders";
+import { DataTable } from "@/components/data-table/data-table";
 import {
     getDraftPayrollsForSettlement,
-    settleAllDraftPayrolls,
+    settleDraftPayrolls,
 } from "./actions";
-import { DataTable } from "@/components/data-table/data-table";
-import { columns } from "./all/columns";
+import { columns as baseColumns, type PayrollWithWorker } from "./all/columns";
+
+const selectableColumns: ColumnDef<PayrollWithWorker>[] = [
+    createRowSelectionColumn<PayrollWithWorker>({
+        ariaLabelForRow: (p) => `Select ${p.workerName}`,
+    }),
+    ...baseColumns,
+];
 
 export function SettleAllDraftPayrollsButton() {
     const router = useRouter();
+    const pathname = usePathname();
     const [open, setOpen] = React.useState(false);
     const [pending, setPending] = React.useState(false);
     const [downloadingZip, setDownloadingZip] = React.useState(false);
@@ -31,8 +42,41 @@ export function SettleAllDraftPayrollsButton() {
     const [drafts, setDrafts] = React.useState<
         Awaited<ReturnType<typeof getDraftPayrollsForSettlement>>
     >([]);
+    const [rowSelection, setRowSelection] = React.useState<RowSelectionState>(
+        {},
+    );
 
     const draftCount = drafts.length;
+    const selectedCount = Object.keys(rowSelection).filter(
+        (k) => rowSelection[k],
+    ).length;
+
+    const resetSettleDialogUi = React.useCallback(() => {
+        setError(null);
+        setLoadingDrafts(false);
+        setRowSelection({});
+    }, []);
+
+    const wasSettleDialogOpen = React.useRef(false);
+    const settleDialogOpenedAtPath = React.useRef<string | null>(null);
+
+    React.useEffect(() => {
+        if (open && !wasSettleDialogOpen.current) {
+            settleDialogOpenedAtPath.current = pathname;
+        }
+        if (!open) {
+            settleDialogOpenedAtPath.current = null;
+        }
+        wasSettleDialogOpen.current = open;
+    }, [open, pathname]);
+
+    React.useEffect(() => {
+        if (!open || settleDialogOpenedAtPath.current === null) return;
+        if (pathname !== settleDialogOpenedAtPath.current) {
+            setOpen(false);
+            resetSettleDialogUi();
+        }
+    }, [pathname, open, resetSettleDialogUi]);
 
     React.useEffect(() => {
         let cancelled = false;
@@ -40,10 +84,14 @@ export function SettleAllDraftPayrollsButton() {
             if (!open) return;
             setLoadingDrafts(true);
             setError(null);
+            setRowSelection({});
             try {
                 const rows = await getDraftPayrollsForSettlement();
                 if (cancelled) return;
                 setDrafts(rows);
+                setRowSelection(
+                    Object.fromEntries(rows.map((r) => [r.id, true])),
+                );
             } catch (e) {
                 if (cancelled) return;
                 console.error("Failed to load draft payrolls", e);
@@ -87,11 +135,16 @@ export function SettleAllDraftPayrollsButton() {
         return null;
     }
 
-    async function handleSettleAll() {
+    async function handleSettleSelected() {
+        const selectedIds = Object.keys(rowSelection).filter(
+            (k) => rowSelection[k],
+        );
+        if (selectedIds.length === 0) return;
+
         setError(null);
         setPending(true);
 
-        const result = await settleAllDraftPayrolls();
+        const result = await settleDraftPayrolls(selectedIds);
 
         setPending(false);
         if (result?.error) {
@@ -135,6 +188,7 @@ export function SettleAllDraftPayrollsButton() {
         }
 
         setOpen(false);
+        resetSettleDialogUi();
         router.refresh();
     }
 
@@ -144,8 +198,7 @@ export function SettleAllDraftPayrollsButton() {
             onOpenChange={(nextOpen) => {
                 setOpen(nextOpen);
                 if (!nextOpen) {
-                    setError(null);
-                    setLoadingDrafts(false);
+                    resetSettleDialogUi();
                 }
             }}>
             <DialogTrigger asChild>
@@ -160,26 +213,28 @@ export function SettleAllDraftPayrollsButton() {
                 <DialogHeader>
                     <DialogTitle>Confirm settlement</DialogTitle>
                     <DialogDescription>
-                        Are you sure you want to settle{" "}
-                        {loadingDrafts ? "Loading..." : `${draftCount}`} draft
-                        payrolls?
+                        {loadingDrafts
+                            ? "Loading draft payrolls…"
+                            : draftCount === 0
+                              ? "There are no draft payrolls to settle."
+                              : "Select the draft payrolls you want to settle. All rows are selected by default."}
                     </DialogDescription>
                 </DialogHeader>
                 <div className="space-y-2">
-                    <div className="flex items-center justify-between gap-3">
-                        <p className="text-sm font-medium tabular-nums"></p>
-                    </div>
-
                     {loadingDrafts ? (
                         <div className="rounded-md border px-3 py-3 text-sm text-muted-foreground">
                             Loading draft payrolls...
                         </div>
                     ) : (
                         <DataTable
-                            columns={columns}
-                            data={drafts}
+                            columns={selectableColumns}
+                            data={drafts as PayrollWithWorker[]}
                             syncSearchToUrl={false}
                             pageSize={5}
+                            enableRowSelection
+                            rowSelection={rowSelection}
+                            onRowSelectionChange={setRowSelection}
+                            getRowId={(row) => row.id}
                         />
                     )}
                 </div>
@@ -202,14 +257,14 @@ export function SettleAllDraftPayrollsButton() {
                             pending ||
                             downloadingZip ||
                             loadingDrafts ||
-                            draftCount === 0
+                            selectedCount === 0
                         }
-                        onClick={handleSettleAll}>
+                        onClick={handleSettleSelected}>
                         {pending
                             ? "Settling..."
                             : downloadingZip
                               ? "Preparing ZIP..."
-                              : "Yes, settle all"}
+                              : `Settle selected (${selectedCount})`}
                     </Button>
                 </DialogFooter>
             </DialogContent>


### PR DESCRIPTION
## Summary

- **Selective bulk settlement:** `settleDraftPayrolls(payrollIds)` validates IDs server-side (existence, draft status) and settles only the selection. The settle dialog uses the same row-selection pattern as download, with all rows selected by default.
- **Modal overlay bug:** Closing the settle and download payroll dialogs when the route changes (e.g. **View** via Next.js `Link`) so the overlay does not block the destination page.

## Files

- `app/dashboard/payroll/actions.ts`
- `app/dashboard/payroll/settle-all-drafts-button.tsx`
- `app/dashboard/payroll/download-payrolls-button.tsx`

Made with [Cursor](https://cursor.com)