### PR TITLE
fix(payroll): voucher & timesheet print contrast, bulk settle, batch PDF download

### DIFF
--- a/app/dashboard/payroll/[id]/payment-voucher.tsx
+++ b/app/dashboard/payroll/[id]/payment-voucher.tsx
@@ -258,79 +258,75 @@ export function PaymentVoucher({
                 </div>
 
                 <div className="space-y-6 p-8">
-                    {/* Metadata grid */}
-                    <div className="grid grid-cols-2 gap-x-12 gap-y-3 text-sm">
-                        <div className="flex items-baseline gap-2">
-                            <span className="font-medium text-neutral-600">
-                                Voucher No:
-                            </span>
-                            <span className="border-b border-neutral-400 px-2 pb-0.5 font-semibold print:border-black">
-                                {voucher.voucherNumber ?? "—"}
-                            </span>
-                        </div>
-                        <div className="flex items-baseline gap-2">
-                            <span className="font-medium text-neutral-600">
-                                Date:
-                            </span>
-                            <span className="border-b border-neutral-400 px-2 pb-0.5 font-semibold print:border-black">
-                                {voucherDate}
-                            </span>
-                        </div>
-                        <div className="flex items-baseline gap-2">
-                            <span className="font-medium text-neutral-600">
-                                Pay to:
-                            </span>
-                            <span className="border-b border-neutral-400 px-2 pb-0.5 font-semibold uppercase tracking-wide print:border-black">
-                                {workerName}
-                            </span>
-                        </div>
-                        <div className="flex items-baseline gap-2">
-                            <span className="font-medium text-neutral-600">
-                                Period:
-                            </span>
-                            <span className="border-b border-neutral-400 px-2 pb-0.5 font-semibold print:border-black">
-                                {periodLabel}
-                            </span>
-                        </div>
-                        <div className="flex items-baseline gap-2">
-                            <span className="font-medium text-neutral-600">
-                                Min. Hours:
-                            </span>
-                            <span className="border-b border-neutral-400 px-2 pb-0.5 font-semibold print:border-black">
-                                {voucher.minimumWorkingHours != null
-                                    ? voucher.minimumWorkingHours.toFixed(2)
-                                    : "—"}
-                            </span>
-                        </div>
-                        <div className="flex items-baseline gap-2">
-                            <span className="font-medium text-neutral-600">
-                                Hours Worked:
-                            </span>
-                            <span className="border-b border-neutral-400 px-2 pb-0.5 font-semibold print:border-black">
-                                {voucher.totalHoursWorked != null
-                                    ? voucher.totalHoursWorked.toFixed(2)
-                                    : "—"}
-                            </span>
-                        </div>
-                    </div>
+                    {/* Metadata table */}
+                    <Table className="w-full text-sm">
+                        <TableBody>
+                            <TableRow className="border-0 hover:bg-white">
+                                <TableCell className="py-2 pr-3 text-right font-medium text-black">
+                                    Voucher No:
+                                </TableCell>
+                                <TableCell className="py-2 pl-3 font-semibold text-black">
+                                    {voucher.voucherNumber ?? "—"}
+                                </TableCell>
+                                <TableCell className="py-2 pr-3 text-right font-medium text-black">
+                                    Date:
+                                </TableCell>
+                                <TableCell className="py-2 pl-3 font-semibold text-black">
+                                    {voucherDate}
+                                </TableCell>
+                            </TableRow>
+                            <TableRow className="border-0 hover:bg-white">
+                                <TableCell className="py-2 pr-3 text-right font-medium text-black">
+                                    Pay to:
+                                </TableCell>
+                                <TableCell className="py-2 pl-3 font-semibold uppercase tracking-wide text-black">
+                                    {workerName}
+                                </TableCell>
+                                <TableCell className="py-2 pr-3 text-right font-medium text-black">
+                                    Period:
+                                </TableCell>
+                                <TableCell className="py-2 pl-3 font-semibold text-black">
+                                    {periodLabel}
+                                </TableCell>
+                            </TableRow>
+                            <TableRow className="border-0 hover:bg-white">
+                                <TableCell className="py-2 pr-3 text-right font-medium text-black">
+                                    Min. Hours:
+                                </TableCell>
+                                <TableCell className="py-2 pl-3 font-semibold text-black">
+                                    {voucher.minimumWorkingHours != null
+                                        ? voucher.minimumWorkingHours.toFixed(2)
+                                        : "—"}
+                                </TableCell>
+                                <TableCell className="py-2 pr-3 text-right font-medium text-black">
+                                    Hours Worked:
+                                </TableCell>
+                                <TableCell className="py-2 pl-3 font-semibold text-black">
+                                    {voucher.totalHoursWorked != null
+                                        ? voucher.totalHoursWorked.toFixed(2)
+                                        : "—"}
+                                </TableCell>
+                            </TableRow>
+                        </TableBody>
+                    </Table>
 
                     {/* Line items table */}
                     <Table className="w-full border-collapse text-sm [&_th]:align-middle [&_td]:align-middle">
                         <TableHeader>
                             <TableRow className="border-y-2 border-black">
-                                <TableHead className="py-2 pl-2 text-left font-semibold">
+                                <TableHead className="py-2 pl-2 text-left font-semibold text-black">
                                     DESCRIPTION
                                 </TableHead>
-                                <TableHead className="w-[60px] py-2 text-center font-semibold">
+                                <TableHead className="w-[60px] py-2 text-center font-semibold text-black">
                                     QTY
                                 </TableHead>
-                                <TableHead className="w-[40px] py-2" />
-                                <TableHead className="w-[20px] py-2" />
-                                <TableHead className="w-[80px] py-2 text-center font-semibold">
+                                <TableHead className="w-[40px] py-2 text-black" />
+                                <TableHead className="w-[20px] py-2 text-black" />
+                                <TableHead className="w-[80px] py-2 text-center font-semibold text-black">
                                     RATE
                                 </TableHead>
                                 <TableHead
-                                    className="w-[140px] border-l border-black py-2 text-center font-semibold"
+                                    className="w-[140px] border-l border-black py-2 text-center font-semibold text-black"
                                     colSpan={2}>
                                     AMOUNT
                                 </TableHead>
@@ -353,7 +349,7 @@ export function PaymentVoucher({
                             {/* Subtotal */}
                             <TableRow className="border-t border-neutral-400">
                                 <TableCell
-                                    className="py-2 pr-4 text-right text-xs font-semibold uppercase tracking-wide text-neutral-500"
+                                    className="py-2 pl-2 text-left text-xs font-semibold uppercase tracking-wide text-black"
                                     colSpan={5}>
                                     Subtotal
                                 </TableCell>
@@ -369,13 +365,13 @@ export function PaymentVoucher({
                                 <ItemRow key={`d-${i}`} item={item} />
                             ))}
                         </TableBody>
-                        <TableFooter>
-                            <TableRow className="border-t-2 border-black">
-                                <TableCell className="py-3 pl-2 text-sm" colSpan={1}>
-                                    A/c
+                        <TableFooter className="bg-white print:bg-white">
+                            <TableRow className="border-t-2 border-black hover:bg-white">
+                                <TableCell className="py-3 pl-2 text-sm font-semibold" colSpan={1}>
+                                    Grand Total
                                 </TableCell>
                                 <TableCell
-                                    className="min-w-[200px] whitespace-nowrap py-3 pl-4 text-sm"
+                                    className="whitespace-nowrap py-3 pr-4 text-right text-sm"
                                     colSpan={4}>
                                     {paymentMethodDisplay}
                                 </TableCell>
@@ -389,40 +385,34 @@ export function PaymentVoucher({
                     </Table>
 
                     {/* Signature blocks */}
-                    <div className="grid grid-cols-2 gap-12 pt-4 text-sm">
-                        <div className="space-y-8">
-                            <p className="font-medium">Payment approved by</p>
-                            <div>
-                                <div className="w-full max-w-[200px] border-b border-black" />
-                                <div className="mt-3 space-y-1 text-xs text-neutral-500">
-                                    <p>
-                                        Name:{" "}
-                                        <span className="inline-block w-32 border-b border-neutral-300" />
-                                    </p>
-                                    <p>
-                                        Date:{" "}
-                                        <span className="inline-block w-32 border-b border-neutral-300" />
-                                    </p>
-                                </div>
-                            </div>
-                        </div>
-                        <div className="space-y-8 text-right">
-                            <p className="font-medium">Payment received by</p>
-                            <div>
-                                <div className="ml-auto w-full max-w-[200px] border-b border-black" />
-                                <div className="mt-3 space-y-1 text-xs text-neutral-500">
-                                    <p>
-                                        Name:{" "}
-                                        <span className="inline-block w-32 border-b border-neutral-300" />
-                                    </p>
-                                    <p>
-                                        Date:{" "}
-                                        <span className="inline-block w-32 border-b border-neutral-300" />
-                                    </p>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
+                    <Table className="w-full text-sm">
+                        <TableBody>
+                            <TableRow className="border-0 hover:bg-white">
+                                <TableCell className="py-2 text-md font-medium text-black">
+                                    Payment approved by Alvis Ong Thai Ying
+                                </TableCell>
+                                <TableCell className="py-2 text-md text-right font-medium text-black">
+                                    Payment received by {workerName}
+                                </TableCell>
+                            </TableRow>
+                            <TableRow className="border-0 hover:bg-white">
+                                <TableCell className="text-black pt-12">
+                                    <div className="w-full max-w-[200px] border-b border-black" />
+                                </TableCell>
+                                <TableCell className="text-black pt-12">
+                                    <div className="ml-auto w-full max-w-[200px] border-b border-black" />
+                                </TableCell>
+                            </TableRow>
+                            <TableRow className="border-0 hover:bg-white">
+                                <TableCell className="pt-4 text-md text-black">
+                                    Date: <span className="border-b border-neutral-300 px-1">{voucherDate}</span>
+                                </TableCell>
+                                <TableCell className="pt-4 text-right text-md text-black">
+                                    Date: <span className="inline-block w-32 border-b border-neutral-300" />
+                                </TableCell>
+                            </TableRow>
+                        </TableBody>
+                    </Table>
                 </div>
             </div>
         </div>

--- a/app/dashboard/payroll/[id]/summarized-timesheet.tsx
+++ b/app/dashboard/payroll/[id]/summarized-timesheet.tsx
@@ -106,7 +106,7 @@ export function SummarizedTimesheet({
                     </p>
                     <p>
                         <span className="font-medium text-neutral-600">
-                            Period Start Date  Period End Date:{" "}
+                            Period:{" "}
                         </span>
                         <span className="font-semibold">{periodLabel}</span>
                     </p>
@@ -115,20 +115,20 @@ export function SummarizedTimesheet({
                 {/* Table */}
                 <Table className="w-full border-collapse text-sm [&_th]:align-middle [&_td]:align-middle print:text-xs">
                     <TableHeader>
-                        <TableRow className="border-y-2 border-black">
-                            <TableHead className="py-2 pl-2 text-left font-semibold print:py-1 print:pl-1">
+                        <TableRow className="border-y-2 border-black hover:bg-white">
+                            <TableHead className="py-2 pl-2 text-left font-semibold text-black print:py-1 print:pl-1">
                                 Date In
                             </TableHead>
-                            <TableHead className="py-2 text-center font-semibold print:py-1">
+                            <TableHead className="py-2 text-center font-semibold text-black print:py-1">
                                 Time in
                             </TableHead>
-                            <TableHead className="py-2 text-center font-semibold print:py-1">
+                            <TableHead className="py-2 text-center font-semibold text-black print:py-1">
                                 Date Out
                             </TableHead>
-                            <TableHead className="py-2 text-center font-semibold print:py-1">
+                            <TableHead className="py-2 text-center font-semibold text-black print:py-1">
                                 Time Out
                             </TableHead>
-                            <TableHead className="py-2 text-center font-semibold print:py-1">
+                            <TableHead className="py-2 pr-2 text-right font-semibold text-black print:py-1 print:pr-1">
                                 Hours
                             </TableHead>
                         </TableRow>
@@ -140,7 +140,7 @@ export function SummarizedTimesheet({
                                 return (
                                     <TableRow
                                         key={`missing-${dayKey}`}
-                                        className="border-b border-neutral-200 text-neutral-500">
+                                        className="border-b border-neutral-200 text-black">
                                         <TableCell className="py-2 pl-2 font-medium print:py-0.5 print:pl-1">
                                             {formatShortDate(dateFromKey(dayKey))}
                                         </TableCell>
@@ -189,8 +189,8 @@ export function SummarizedTimesheet({
                             ));
                         })}
                     </TableBody>
-                    <TableFooter>
-                        <TableRow className="border-t-2 border-black">
+                    <TableFooter className="bg-white print:bg-white">
+                        <TableRow className="border-t-2 border-black hover:bg-white">
                             <TableCell
                                 className="py-3 pl-2 font-semibold print:py-1 print:pl-1"
                                 colSpan={4}>

--- a/app/dashboard/payroll/actions.ts
+++ b/app/dashboard/payroll/actions.ts
@@ -780,27 +780,55 @@ export async function settlePayroll(payrollId: string) {
     return { success: true };
 }
 
-export async function settleAllDraftPayrolls() {
+class SettleDraftPayrollsValidationError extends Error {
+    readonly code: "NOT_FOUND" | "NOT_DRAFT";
+
+    constructor(code: "NOT_FOUND" | "NOT_DRAFT") {
+        super(code);
+        this.code = code;
+        this.name = "SettleDraftPayrollsValidationError";
+    }
+}
+
+export async function settleDraftPayrolls(payrollIds: string[]) {
     await requirePermission("Payroll", "update");
+
+    const uniqueIds = Array.from(new Set(payrollIds));
+    if (uniqueIds.length === 0) {
+        return { error: "Select at least one payroll to settle" };
+    }
 
     const now = new Date();
 
     let settledPayrollIds: string[] = [];
     try {
         settledPayrollIds = await db.transaction(async (tx) => {
-            const drafts = await tx
+            const rows = await tx
                 .select()
                 .from(payrollTable)
-                .where(eq(payrollTable.status, "draft"));
+                .where(inArray(payrollTable.id, uniqueIds));
 
-            for (const payroll of drafts) {
-                await settlePayrollInTx(tx, payroll, now);
+            if (rows.length !== uniqueIds.length) {
+                throw new SettleDraftPayrollsValidationError("NOT_FOUND");
+            }
+            if (rows.some((r) => r.status !== "draft")) {
+                throw new SettleDraftPayrollsValidationError("NOT_DRAFT");
             }
 
-            return drafts.map((p) => p.id);
+            const sorted = [...rows].sort((a, b) => a.id.localeCompare(b.id));
+            for (const payroll of sorted) {
+                await settlePayrollInTx(tx, payroll, now);
+            }
+            return sorted.map((p) => p.id);
         });
     } catch (error) {
-        console.error("Error settling all draft payrolls", error);
+        if (error instanceof SettleDraftPayrollsValidationError) {
+            if (error.code === "NOT_FOUND") {
+                return { error: "One or more payrolls were not found" };
+            }
+            return { error: "One or more payrolls are not drafts" };
+        }
+        console.error("Error settling draft payrolls", error);
         return { error: "Failed to settle draft payrolls" };
     }
 

--- a/app/dashboard/payroll/download-payrolls-button.tsx
+++ b/app/dashboard/payroll/download-payrolls-button.tsx
@@ -4,6 +4,7 @@ import * as React from "react";
 import type { ColumnDef } from "@tanstack/react-table";
 import type { RowSelectionState } from "@tanstack/react-table";
 import { Download } from "lucide-react";
+import { usePathname } from "next/navigation";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -55,6 +56,7 @@ function getDownloadFilenameFromContentDisposition(
 }
 
 export function DownloadPayrollsButton() {
+    const pathname = usePathname();
     const [open, setOpen] = React.useState(false);
     const [downloading, setDownloading] = React.useState(false);
     const [error, setError] = React.useState<string | null>(null);
@@ -67,6 +69,32 @@ export function DownloadPayrollsButton() {
     const selectedCount = Object.keys(rowSelection).filter(
         (k) => rowSelection[k],
     ).length;
+
+    const resetDownloadDialogUi = React.useCallback(() => {
+        setError(null);
+        setLoading(false);
+    }, []);
+
+    const wasDownloadDialogOpen = React.useRef(false);
+    const downloadDialogOpenedAtPath = React.useRef<string | null>(null);
+
+    React.useEffect(() => {
+        if (open && !wasDownloadDialogOpen.current) {
+            downloadDialogOpenedAtPath.current = pathname;
+        }
+        if (!open) {
+            downloadDialogOpenedAtPath.current = null;
+        }
+        wasDownloadDialogOpen.current = open;
+    }, [open, pathname]);
+
+    React.useEffect(() => {
+        if (!open || downloadDialogOpenedAtPath.current === null) return;
+        if (pathname !== downloadDialogOpenedAtPath.current) {
+            setOpen(false);
+            resetDownloadDialogUi();
+        }
+    }, [pathname, open, resetDownloadDialogUi]);
 
     React.useEffect(() => {
         let cancelled = false;
@@ -125,6 +153,7 @@ export function DownloadPayrollsButton() {
             a.remove();
             URL.revokeObjectURL(url);
             setOpen(false);
+            resetDownloadDialogUi();
         } catch (e) {
             console.error(e);
             setError("Failed to download payroll PDFs");
@@ -139,8 +168,7 @@ export function DownloadPayrollsButton() {
             onOpenChange={(nextOpen) => {
                 setOpen(nextOpen);
                 if (!nextOpen) {
-                    setError(null);
-                    setLoading(false);
+                    resetDownloadDialogUi();
                 }
             }}>
             <DialogTrigger asChild>

--- a/app/dashboard/payroll/settle-all-drafts-button.tsx
+++ b/app/dashboard/payroll/settle-all-drafts-button.tsx
@@ -1,7 +1,9 @@
 "use client";
 
 import * as React from "react";
-import { useRouter } from "next/navigation";
+import type { ColumnDef } from "@tanstack/react-table";
+import type { RowSelectionState } from "@tanstack/react-table";
+import { usePathname, useRouter } from "next/navigation";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -14,15 +16,24 @@ import {
     DialogTitle,
     DialogTrigger,
 } from "@/components/ui/dialog";
+import { createRowSelectionColumn } from "@/components/data-table/column-builders";
+import { DataTable } from "@/components/data-table/data-table";
 import {
     getDraftPayrollsForSettlement,
-    settleAllDraftPayrolls,
+    settleDraftPayrolls,
 } from "./actions";
-import { DataTable } from "@/components/data-table/data-table";
-import { columns } from "./all/columns";
+import { columns as baseColumns, type PayrollWithWorker } from "./all/columns";
+
+const selectableColumns: ColumnDef<PayrollWithWorker>[] = [
+    createRowSelectionColumn<PayrollWithWorker>({
+        ariaLabelForRow: (p) => `Select ${p.workerName}`,
+    }),
+    ...baseColumns,
+];
 
 export function SettleAllDraftPayrollsButton() {
     const router = useRouter();
+    const pathname = usePathname();
     const [open, setOpen] = React.useState(false);
     const [pending, setPending] = React.useState(false);
     const [downloadingZip, setDownloadingZip] = React.useState(false);
@@ -31,8 +42,41 @@ export function SettleAllDraftPayrollsButton() {
     const [drafts, setDrafts] = React.useState<
         Awaited<ReturnType<typeof getDraftPayrollsForSettlement>>
     >([]);
+    const [rowSelection, setRowSelection] = React.useState<RowSelectionState>(
+        {},
+    );
 
     const draftCount = drafts.length;
+    const selectedCount = Object.keys(rowSelection).filter(
+        (k) => rowSelection[k],
+    ).length;
+
+    const resetSettleDialogUi = React.useCallback(() => {
+        setError(null);
+        setLoadingDrafts(false);
+        setRowSelection({});
+    }, []);
+
+    const wasSettleDialogOpen = React.useRef(false);
+    const settleDialogOpenedAtPath = React.useRef<string | null>(null);
+
+    React.useEffect(() => {
+        if (open && !wasSettleDialogOpen.current) {
+            settleDialogOpenedAtPath.current = pathname;
+        }
+        if (!open) {
+            settleDialogOpenedAtPath.current = null;
+        }
+        wasSettleDialogOpen.current = open;
+    }, [open, pathname]);
+
+    React.useEffect(() => {
+        if (!open || settleDialogOpenedAtPath.current === null) return;
+        if (pathname !== settleDialogOpenedAtPath.current) {
+            setOpen(false);
+            resetSettleDialogUi();
+        }
+    }, [pathname, open, resetSettleDialogUi]);
 
     React.useEffect(() => {
         let cancelled = false;
@@ -40,10 +84,14 @@ export function SettleAllDraftPayrollsButton() {
             if (!open) return;
             setLoadingDrafts(true);
             setError(null);
+            setRowSelection({});
             try {
                 const rows = await getDraftPayrollsForSettlement();
                 if (cancelled) return;
                 setDrafts(rows);
+                setRowSelection(
+                    Object.fromEntries(rows.map((r) => [r.id, true])),
+                );
             } catch (e) {
                 if (cancelled) return;
                 console.error("Failed to load draft payrolls", e);
@@ -87,11 +135,16 @@ export function SettleAllDraftPayrollsButton() {
         return null;
     }
 
-    async function handleSettleAll() {
+    async function handleSettleSelected() {
+        const selectedIds = Object.keys(rowSelection).filter(
+            (k) => rowSelection[k],
+        );
+        if (selectedIds.length === 0) return;
+
         setError(null);
         setPending(true);
 
-        const result = await settleAllDraftPayrolls();
+        const result = await settleDraftPayrolls(selectedIds);
 
         setPending(false);
         if (result?.error) {
@@ -135,6 +188,7 @@ export function SettleAllDraftPayrollsButton() {
         }
 
         setOpen(false);
+        resetSettleDialogUi();
         router.refresh();
     }
 
@@ -144,8 +198,7 @@ export function SettleAllDraftPayrollsButton() {
             onOpenChange={(nextOpen) => {
                 setOpen(nextOpen);
                 if (!nextOpen) {
-                    setError(null);
-                    setLoadingDrafts(false);
+                    resetSettleDialogUi();
                 }
             }}>
             <DialogTrigger asChild>
@@ -160,26 +213,28 @@ export function SettleAllDraftPayrollsButton() {
                 <DialogHeader>
                     <DialogTitle>Confirm settlement</DialogTitle>
                     <DialogDescription>
-                        Are you sure you want to settle{" "}
-                        {loadingDrafts ? "Loading..." : `${draftCount}`} draft
-                        payrolls?
+                        {loadingDrafts
+                            ? "Loading draft payrolls…"
+                            : draftCount === 0
+                              ? "There are no draft payrolls to settle."
+                              : "Select the draft payrolls you want to settle. All rows are selected by default."}
                     </DialogDescription>
                 </DialogHeader>
                 <div className="space-y-2">
-                    <div className="flex items-center justify-between gap-3">
-                        <p className="text-sm font-medium tabular-nums"></p>
-                    </div>
-
                     {loadingDrafts ? (
                         <div className="rounded-md border px-3 py-3 text-sm text-muted-foreground">
                             Loading draft payrolls...
                         </div>
                     ) : (
                         <DataTable
-                            columns={columns}
-                            data={drafts}
+                            columns={selectableColumns}
+                            data={drafts as PayrollWithWorker[]}
                             syncSearchToUrl={false}
                             pageSize={5}
+                            enableRowSelection
+                            rowSelection={rowSelection}
+                            onRowSelectionChange={setRowSelection}
+                            getRowId={(row) => row.id}
                         />
                     )}
                 </div>
@@ -202,14 +257,14 @@ export function SettleAllDraftPayrollsButton() {
                             pending ||
                             downloadingZip ||
                             loadingDrafts ||
-                            draftCount === 0
+                            selectedCount === 0
                         }
-                        onClick={handleSettleAll}>
+                        onClick={handleSettleSelected}>
                         {pending
                             ? "Settling..."
                             : downloadingZip
                               ? "Preparing ZIP..."
-                              : "Yes, settle all"}
+                              : `Settle selected (${selectedCount})`}
                     </Button>
                 </DialogFooter>
             </DialogContent>


### PR DESCRIPTION
## Summary

### Print contrast fixes (`payment-voucher.tsx`, `summarized-timesheet.tsx`)
- Override shadcn `TableHead`/`TableFooter`/`TableRow` defaults at call sites to force black text and white backgrounds for print-ready output
- Restructure voucher metadata from a flex-based grid to a clean 4-column shadcn `Table` with right-aligned labels and no borders
- Convert signature blocks to a shadcn `Table` with pre-filled approver name/date and worker name
- Rename footer label from "A/c" to "Grand Total"; flush payment method to the right; left-align "Subtotal"
- Right-align timesheet "Hours" column header, fix missing-day row text to black, rename period label to "Period:"

### Selective bulk settle (`settle-all-drafts-button.tsx`, `actions.ts`)
- Add checkbox-based selection for bulk settling draft payrolls instead of settling all at once
- Close settle dialog on navigation

### Batch PDF download (`download-payrolls-button.tsx`, `download-zip/route.ts`)
- Add batch download button that generates a ZIP of payroll PDFs
- Rename route from `settled-zip` to `download-zip`

## Test plan

- [ ] Open payroll summary page — verify voucher headers (DESCRIPTION, QTY, RATE, AMOUNT) render in black text
- [ ] Verify voucher and timesheet footer rows have white backgrounds (no grey band)
- [ ] Verify voucher metadata is a clean aligned table; signature blocks show approver and worker names
- [ ] Browser print preview and PDF download both match the on-screen rendering
- [ ] Bulk settle dialog opens with checkboxes, allows selective settlement, closes on navigation
- [ ] Batch PDF download generates a valid ZIP with correct filenames