### PR TITLE
feat(advance): add breakdown summary flow with PDF export

### DIFF
--- a/app/api/advance/[id]/pdf/route.ts
+++ b/app/api/advance/[id]/pdf/route.ts
@@ -1,0 +1,107 @@
+import { NextRequest } from "next/server";
+import { chromium } from "playwright";
+import { eq } from "drizzle-orm";
+
+import { auth } from "@/lib/auth";
+import { db } from "@/lib/db";
+import { checkPermission } from "@/utils/permissions/permissions";
+import { advanceRequestTable } from "@/db/tables/payroll/advanceRequestTable";
+import { workerTable } from "@/db/tables/payroll/workerTable";
+
+export const runtime = "nodejs";
+
+function safeFilenamePart(s: string): string {
+    return String(s).replace(/[/\\:*?"<>|]/g, "-").trim();
+}
+
+function isoToDdmmyyyy(val: unknown): string {
+    const s = String(val instanceof Date ? val.toISOString() : val).slice(0, 10);
+    const [y, m, d] = s.split("-");
+    if (!y || !m || !d) return s;
+    return `${d}_${m}_${y}`;
+}
+
+async function requireApiPermission(req: NextRequest) {
+    const session = await auth.api.getSession({ headers: req.headers });
+    if (!session) {
+        return { ok: false as const, status: 401 as const };
+    }
+    const allowed = await checkPermission(session.user.id, "Advance", "read");
+    if (!allowed) {
+        return { ok: false as const, status: 403 as const };
+    }
+    return { ok: true as const, userId: session.user.id };
+}
+
+export async function GET(
+    req: NextRequest,
+    ctx: { params: Promise<{ id: string }> },
+) {
+    const perm = await requireApiPermission(req);
+    if (!perm.ok) {
+        return new Response("Unauthorized", { status: perm.status });
+    }
+
+    const { id } = await ctx.params;
+
+    const url = `${req.nextUrl.origin}/dashboard/advance/${id}/summary?print=1`;
+
+    const [meta] = await db
+        .select({
+            workerName: workerTable.name,
+            amountRequested: advanceRequestTable.amountRequested,
+            requestDate: advanceRequestTable.requestDate,
+        })
+        .from(advanceRequestTable)
+        .innerJoin(workerTable, eq(advanceRequestTable.workerId, workerTable.id))
+        .where(eq(advanceRequestTable.id, id))
+        .limit(1);
+
+    const cookie = req.headers.get("cookie") ?? "";
+
+    const browser = await chromium.launch({
+        headless: true,
+        args: ["--no-sandbox"],
+    });
+    try {
+        const page = await browser.newPage({
+            viewport: { width: 1240, height: 1754 },
+        });
+        if (cookie) {
+            await page.setExtraHTTPHeaders({ cookie });
+        }
+
+        await page.goto(url, { waitUntil: "networkidle" });
+        await page.emulateMedia({ media: "print" });
+        await page.evaluate(async () => {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const fonts = (document as any).fonts;
+            if (fonts?.ready) await fonts.ready;
+        });
+
+        const pdf = await page.pdf({
+            format: "A4",
+            printBackground: true,
+            preferCSSPageSize: true,
+            scale: 1,
+            margin: { top: "10mm", right: "10mm", bottom: "10mm", left: "10mm" },
+        });
+
+        const workerName = meta?.workerName ?? `advance-${id}`;
+        const amount = meta?.amountRequested ?? 0;
+        const requestDate = isoToDdmmyyyy(meta?.requestDate ?? "");
+        const filename = safeFilenamePart(
+            `${workerName} - Advance - $${amount} - ${requestDate}.pdf`,
+        );
+
+        return new Response(new Uint8Array(pdf), {
+            headers: {
+                "Content-Type": "application/pdf",
+                "Content-Disposition": `attachment; filename="${filename}"`,
+                "Cache-Control": "no-store",
+            },
+        });
+    } finally {
+        await browser.close();
+    }
+}

--- a/app/dashboard/advance/[id]/advance-printable.tsx
+++ b/app/dashboard/advance/[id]/advance-printable.tsx
@@ -1,0 +1,203 @@
+import {
+    Table,
+    TableHeader,
+    TableBody,
+    TableFooter,
+    TableRow,
+    TableHead,
+    TableCell,
+} from "@/components/ui/table";
+import type { AdvanceRequestDetail } from "@/utils/advance/queries";
+
+const currencyFmt = new Intl.NumberFormat("en-US", {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+});
+
+function formatDate(iso: string | null): string {
+    if (!iso) return "—";
+    const d = new Date(iso + "T00:00:00");
+    return d.toLocaleDateString("en-GB", {
+        day: "numeric",
+        month: "long",
+        year: "numeric",
+    });
+}
+
+export function AdvancePrintable({ detail }: { detail: AdvanceRequestDetail }) {
+    const { request, advances, purpose } = detail;
+
+    const totalAmount = advances.reduce((sum, a) => sum + a.amount, 0);
+    const paidCount = advances.filter((a) => a.status === "paid").length;
+    const outstandingCount = advances.length - paidCount;
+
+    return (
+        <div className="advance-print-root overflow-hidden border border-neutral-300 bg-white text-black print:border-black print:break-inside-avoid">
+            {/* Header */}
+            <div className="border-b border-neutral-300 px-8 pt-6 pb-4 print:border-black">
+                <h2 className="text-center text-xl font-bold tracking-[0.2em] text-neutral-900">
+                    ADVANCE REQUEST
+                </h2>
+            </div>
+
+            <div className="space-y-6 p-8">
+                {/* Metadata grid */}
+                <div className="grid grid-cols-2 gap-x-12 gap-y-3 text-sm">
+                    <div className="flex items-baseline gap-2">
+                        <span className="font-medium text-neutral-600">
+                            Employee:
+                        </span>
+                        <span className="border-b border-neutral-400 px-2 pb-0.5 font-semibold uppercase tracking-wide print:border-black">
+                            {request.workerName}
+                        </span>
+                    </div>
+                    <div className="flex items-baseline gap-2">
+                        <span className="font-medium text-neutral-600">
+                            Date of Request:
+                        </span>
+                        <span className="border-b border-neutral-400 px-2 pb-0.5 font-semibold print:border-black">
+                            {formatDate(request.requestDate)}
+                        </span>
+                    </div>
+                    <div className="flex items-baseline gap-2">
+                        <span className="font-medium text-neutral-600">
+                            Amount Requested:
+                        </span>
+                        <span className="border-b border-neutral-400 px-2 pb-0.5 font-semibold print:border-black">
+                            ${currencyFmt.format(request.amountRequested)}
+                        </span>
+                    </div>
+                    <div className="flex items-baseline gap-2">
+                        <span className="font-medium text-neutral-600">
+                            Status:
+                        </span>
+                        <span className="border-b border-neutral-400 px-2 pb-0.5 font-semibold capitalize print:border-black">
+                            {request.status}
+                        </span>
+                    </div>
+                </div>
+
+                {/* Purpose */}
+                {purpose ? (
+                    <div className="text-sm">
+                        <p className="mb-1 font-medium text-neutral-600">
+                            Purpose:
+                        </p>
+                        <p className="whitespace-pre-wrap rounded border border-neutral-200 bg-neutral-50 px-3 py-2 print:border-black print:bg-transparent">
+                            {purpose}
+                        </p>
+                    </div>
+                ) : null}
+
+                {/* Repayment schedule */}
+                <div>
+                    <p className="mb-2 text-sm font-semibold uppercase tracking-wide text-neutral-700">
+                        Repayment Schedule
+                    </p>
+                    <Table className="w-full border-collapse text-sm [&_th]:align-middle [&_td]:align-middle">
+                        <TableHeader>
+                            <TableRow className="border-y-2 border-black">
+                                <TableHead className="w-[50px] py-2 pl-2 text-center font-semibold">
+                                    #
+                                </TableHead>
+                                <TableHead className="py-2 text-left font-semibold">
+                                    AMOUNT
+                                </TableHead>
+                                <TableHead className="py-2 text-left font-semibold">
+                                    REPAYMENT DATE
+                                </TableHead>
+                                <TableHead className="py-2 text-left font-semibold">
+                                    STATUS
+                                </TableHead>
+                            </TableRow>
+                        </TableHeader>
+                        <TableBody>
+                            {advances.map((adv, i) => (
+                                <TableRow
+                                    key={adv.id}
+                                    className="border-b border-neutral-200">
+                                    <TableCell className="py-2 pl-2 text-center">
+                                        {i + 1}
+                                    </TableCell>
+                                    <TableCell className="py-2 font-medium">
+                                        ${currencyFmt.format(adv.amount)}
+                                    </TableCell>
+                                    <TableCell className="py-2">
+                                        {formatDate(adv.repaymentDate)}
+                                    </TableCell>
+                                    <TableCell className="py-2 capitalize">
+                                        {adv.status}
+                                    </TableCell>
+                                </TableRow>
+                            ))}
+                        </TableBody>
+                        <TableFooter>
+                            <TableRow className="border-t-2 border-black">
+                                <TableCell className="py-3 pl-2 text-center font-semibold">
+                                    {advances.length}
+                                </TableCell>
+                                <TableCell className="py-3 text-base font-bold">
+                                    ${currencyFmt.format(totalAmount)}
+                                </TableCell>
+                                <TableCell className="py-3" />
+                                <TableCell className="py-3 text-xs text-neutral-500">
+                                    {paidCount} paid / {outstandingCount}{" "}
+                                    outstanding
+                                </TableCell>
+                            </TableRow>
+                        </TableFooter>
+                    </Table>
+                </div>
+
+                {/* Declaration */}
+                <div className="rounded border border-neutral-200 px-4 py-3 text-sm print:border-black">
+                    <p className="mb-1 font-semibold text-neutral-700">
+                        Employee Acknowledgment
+                    </p>
+                    <p className="leading-relaxed text-neutral-600 print:text-black">
+                        I acknowledge that this advance is a loan and will be
+                        repaid according to the agreed terms. I authorize the
+                        company to deduct the repayment from my salary as
+                        specified.
+                    </p>
+                </div>
+
+                {/* Signature blocks */}
+                <div className="grid grid-cols-2 gap-12 pt-4 text-sm">
+                    <div className="space-y-8">
+                        <p className="font-medium">Employee signature</p>
+                        <div>
+                            <div className="w-full max-w-[200px] border-b border-black" />
+                            <div className="mt-3 space-y-1 text-xs text-neutral-500">
+                                <p>
+                                    Name:{" "}
+                                    <span className="inline-block w-32 border-b border-neutral-300" />
+                                </p>
+                                <p>
+                                    Date signed:{" "}
+                                    <span className="inline-block w-32 border-b border-neutral-300" />
+                                </p>
+                            </div>
+                        </div>
+                    </div>
+                    <div className="space-y-8 text-right">
+                        <p className="font-medium">Manager&apos;s signature</p>
+                        <div>
+                            <div className="ml-auto w-full max-w-[200px] border-b border-black" />
+                            <div className="mt-3 space-y-1 text-xs text-neutral-500">
+                                <p>
+                                    Name:{" "}
+                                    <span className="inline-block w-32 border-b border-neutral-300" />
+                                </p>
+                                <p>
+                                    Date signed:{" "}
+                                    <span className="inline-block w-32 border-b border-neutral-300" />
+                                </p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/app/dashboard/advance/[id]/advance-step-progress.tsx
+++ b/app/dashboard/advance/[id]/advance-step-progress.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import Link from "next/link";
+
+interface AdvanceStepProgressProps {
+    className?: string;
+    advanceRequestId: string;
+    activeStep: 1 | 2;
+}
+
+export function AdvanceStepProgress({
+    className,
+    advanceRequestId,
+    activeStep,
+}: AdvanceStepProgressProps) {
+    const step1Active = activeStep === 1;
+    const step2Active = activeStep === 2;
+
+    return (
+        <div className={className}>
+            <div className="rounded-xl border bg-card px-4 py-4">
+                <div className="flex flex-col gap-3">
+                    <Link
+                        href={`/dashboard/advance/${advanceRequestId}/breakdown`}
+                        className="flex items-center gap-2">
+                        <div
+                            className={`flex h-7 w-7 items-center justify-center rounded-full border text-xs font-semibold ${
+                                step1Active
+                                    ? "border-primary bg-primary text-primary-foreground"
+                                    : "border-muted-foreground/40 bg-muted text-muted-foreground"
+                            }`}>
+                            1
+                        </div>
+                        <span
+                            className={`text-sm font-medium ${
+                                step1Active
+                                    ? "text-foreground"
+                                    : "text-muted-foreground"
+                            }`}>
+                            Advance Breakdown
+                        </span>
+                    </Link>
+
+                    <div className="flex h-6 pl-3">
+                        <div
+                            className={`w-0.5 rounded-full ${
+                                step2Active ? "bg-primary/80" : "bg-muted"
+                            }`}
+                        />
+                    </div>
+
+                    <Link
+                        href={`/dashboard/advance/${advanceRequestId}/summary`}
+                        className="flex items-center gap-2">
+                        <div
+                            className={`flex h-7 w-7 items-center justify-center rounded-full border text-xs font-semibold ${
+                                step2Active
+                                    ? "border-primary bg-primary text-primary-foreground"
+                                    : "border-muted-foreground/40 bg-muted text-muted-foreground"
+                            }`}>
+                            2
+                        </div>
+                        <span
+                            className={`text-sm font-medium ${
+                                step2Active
+                                    ? "text-foreground"
+                                    : "text-muted-foreground"
+                            }`}>
+                            Summary & Download
+                        </span>
+                    </Link>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/app/dashboard/advance/[id]/advance-summary-capture.tsx
+++ b/app/dashboard/advance/[id]/advance-summary-capture.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { Download } from "lucide-react";
+import { useRouter, useSearchParams } from "next/navigation";
+
+import { Button } from "@/components/ui/button";
+
+function isoToDdmmyyyy(iso: string): string {
+    const s = String(iso).slice(0, 10);
+    const [y, m, d] = s.split("-");
+    if (!y || !m || !d) return s;
+    return `${d}_${m}_${y}`;
+}
+
+export function AdvanceSummaryCapture(props: {
+    advanceRequestId: string;
+    workerName: string;
+    amountRequested: number;
+    requestDate: string;
+    children: React.ReactNode;
+}) {
+    const {
+        advanceRequestId,
+        workerName,
+        amountRequested,
+        requestDate,
+        children,
+    } = props;
+    const rootRef = useRef<HTMLDivElement | null>(null);
+    const [isGenerating, setIsGenerating] = useState(false);
+    const router = useRouter();
+    const searchParams = useSearchParams();
+
+    async function handleDownloadPdf() {
+        if (isGenerating) return;
+
+        setIsGenerating(true);
+        try {
+            const res = await fetch(
+                `/api/advance/${advanceRequestId}/pdf`,
+                { method: "GET", cache: "no-store" },
+            );
+            if (!res.ok) throw new Error(`PDF download failed (${res.status})`);
+            const blob = await res.blob();
+            const url = URL.createObjectURL(blob);
+            const a = document.createElement("a");
+            a.href = url;
+            a.download = `${workerName} - Advance - $${amountRequested} - ${isoToDdmmyyyy(requestDate)}.pdf`;
+            document.body.appendChild(a);
+            a.click();
+            a.remove();
+            URL.revokeObjectURL(url);
+        } finally {
+            setIsGenerating(false);
+        }
+    }
+
+    useEffect(() => {
+        if (searchParams.get("download") !== "1") return;
+
+        let cancelled = false;
+        async function run() {
+            await handleDownloadPdf();
+            if (cancelled) return;
+
+            const path = window.location.pathname;
+            const next = new URLSearchParams(searchParams.toString());
+            next.delete("download");
+            const qs = next.toString();
+            router.replace(qs ? `${path}?${qs}` : path, { scroll: false });
+        }
+
+        requestAnimationFrame(() => {
+            void run();
+        });
+
+        return () => {
+            cancelled = true;
+        };
+    }, [searchParams, router, workerName, amountRequested, requestDate]);
+
+    return (
+        <div className="space-y-3">
+            <div className="w-full print:hidden">
+                <Button
+                    size="lg"
+                    className="h-12 w-full text-base"
+                    onClick={handleDownloadPdf}
+                    disabled={isGenerating}>
+                    <Download className="mr-2 h-4 w-4" />
+                    {isGenerating ? "Generating…" : "Download PDF"}
+                </Button>
+            </div>
+
+            <div
+                ref={rootRef}
+                className="space-y-3 printable-advance print:bg-white">
+                {children}
+            </div>
+        </div>
+    );
+}

--- a/app/dashboard/advance/[id]/breakdown/page.tsx
+++ b/app/dashboard/advance/[id]/breakdown/page.tsx
@@ -1,0 +1,57 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+
+import { Button } from "@/components/ui/button";
+import { FormPageLayout } from "@/components/form-page-layout";
+import { getAdvanceRequestByIdWithWorker } from "@/utils/advance/queries";
+import { requirePermission } from "@/utils/permissions/require-permission";
+import { checkPermission } from "@/utils/permissions/permissions";
+import { Pencil } from "lucide-react";
+
+import { AdvanceRequestForm } from "../../advance-request-form";
+import { AdvanceStepProgress } from "../advance-step-progress";
+
+export default async function AdvanceBreakdownPage({
+    params,
+}: {
+    params: Promise<{ id: string }>;
+}) {
+    const { userId } = await requirePermission("Advance", "read");
+    const canUpdate = await checkPermission(userId, "Advance", "update");
+
+    const { id } = await params;
+    const detail = await getAdvanceRequestByIdWithWorker(id);
+    if (!detail) {
+        notFound();
+    }
+
+    return (
+        <FormPageLayout
+            title="Advance request"
+            subtitle={`Detail for worker ${detail.request.workerName}`}
+            actions={
+                !canUpdate || detail.request.status === "paid" ? (
+                    <Button variant="outline" size="sm" disabled>
+                        <Pencil className="h-4 w-4" />
+                        Edit
+                    </Button>
+                ) : (
+                    <Button asChild variant="outline" size="sm">
+                        <Link
+                            href={`/dashboard/advance/${id}/edit`}
+                            className="flex items-center gap-2">
+                            <Pencil className="h-4 w-4" />
+                            Edit
+                        </Link>
+                    </Button>
+                )
+            }>
+            <AdvanceStepProgress advanceRequestId={id} activeStep={1} />
+            <AdvanceRequestForm
+                readOnly
+                initialData={detail}
+                advanceRequestId={id}
+            />
+        </FormPageLayout>
+    );
+}

--- a/app/dashboard/advance/[id]/page.tsx
+++ b/app/dashboard/advance/[id]/page.tsx
@@ -1,55 +1,10 @@
-import Link from "next/link";
-import { notFound } from "next/navigation";
+import { redirect } from "next/navigation";
 
-import { Button } from "@/components/ui/button";
-import { FormPageLayout } from "@/components/form-page-layout";
-import { getAdvanceRequestByIdWithWorker } from "@/utils/advance/queries";
-import { requirePermission } from "@/utils/permissions/require-permission";
-import { checkPermission } from "@/utils/permissions/permissions";
-import { Pencil } from "lucide-react";
-
-import { AdvanceRequestForm } from "../advance-request-form";
-
-export default async function AdvanceDetailPage({
-    params,
-}: {
+interface PageProps {
     params: Promise<{ id: string }>;
-}) {
-    const { userId } = await requirePermission("Advance", "read");
-    const canUpdate = await checkPermission(userId, "Advance", "update");
+}
 
+export default async function AdvanceDetailPage({ params }: PageProps) {
     const { id } = await params;
-    const detail = await getAdvanceRequestByIdWithWorker(id);
-    if (!detail) {
-        notFound();
-    }
-
-    return (
-        <FormPageLayout
-            title="Advance request"
-            subtitle={`Detail for worker ${detail.request.workerName}`}
-            actions={
-                !canUpdate || detail.request.status === "paid" ? (
-                    <Button variant="outline" size="sm" disabled>
-                        <Pencil className="h-4 w-4" />
-                        Edit
-                    </Button>
-                ) : (
-                    <Button asChild variant="outline" size="sm">
-                        <Link
-                            href={`/dashboard/advance/${id}/edit`}
-                            className="flex items-center gap-2">
-                            <Pencil className="h-4 w-4" />
-                            Edit
-                        </Link>
-                    </Button>
-                )
-            }>
-            <AdvanceRequestForm
-                readOnly
-                initialData={detail}
-                advanceRequestId={id}
-            />
-        </FormPageLayout>
-    );
+    redirect(`/dashboard/advance/${id}/breakdown`);
 }

--- a/app/dashboard/advance/[id]/summary/page.tsx
+++ b/app/dashboard/advance/[id]/summary/page.tsx
@@ -1,8 +1,12 @@
+import Link from "next/link";
 import { notFound } from "next/navigation";
 
+import { Button } from "@/components/ui/button";
 import { FormPageLayout } from "@/components/form-page-layout";
 import { getAdvanceRequestByIdWithWorker } from "@/utils/advance/queries";
 import { requirePermission } from "@/utils/permissions/require-permission";
+import { checkPermission } from "@/utils/permissions/permissions";
+import { Pencil } from "lucide-react";
 
 import { AdvanceStepProgress } from "../advance-step-progress";
 import { AdvanceSummaryCapture } from "../advance-summary-capture";
@@ -13,18 +17,36 @@ interface PageProps {
 }
 
 export default async function AdvanceSummaryPage({ params }: PageProps) {
-    await requirePermission("Advance", "read");
+    const { userId } = await requirePermission("Advance", "read");
 
     const { id } = await params;
     const detail = await getAdvanceRequestByIdWithWorker(id);
     if (!detail) {
         notFound();
     }
+    const canUpdate = await checkPermission(userId, "Advance", "update");
 
     return (
         <FormPageLayout
             title="Advance request"
-            subtitle={`Summary for worker ${detail.request.workerName}`}>
+            subtitle={`Summary for worker ${detail.request.workerName}`}
+            actions={
+                !canUpdate || detail.request.status === "paid" ? (
+                    <Button variant="outline" size="sm" disabled>
+                        <Pencil className="h-4 w-4" />
+                        Edit
+                    </Button>
+                ) : (
+                    <Button asChild variant="outline" size="sm">
+                        <Link
+                            href={`/dashboard/advance/${id}/edit`}
+                            className="flex items-center gap-2">
+                            <Pencil className="h-4 w-4" />
+                            Edit
+                        </Link>
+                    </Button>
+                )
+            }>
             <AdvanceStepProgress
                 className="print:hidden"
                 advanceRequestId={id}

--- a/app/dashboard/advance/[id]/summary/page.tsx
+++ b/app/dashboard/advance/[id]/summary/page.tsx
@@ -1,0 +1,45 @@
+import { notFound } from "next/navigation";
+
+import { FormPageLayout } from "@/components/form-page-layout";
+import { getAdvanceRequestByIdWithWorker } from "@/utils/advance/queries";
+import { requirePermission } from "@/utils/permissions/require-permission";
+
+import { AdvanceStepProgress } from "../advance-step-progress";
+import { AdvanceSummaryCapture } from "../advance-summary-capture";
+import { AdvancePrintable } from "../advance-printable";
+
+interface PageProps {
+    params: Promise<{ id: string }>;
+}
+
+export default async function AdvanceSummaryPage({ params }: PageProps) {
+    await requirePermission("Advance", "read");
+
+    const { id } = await params;
+    const detail = await getAdvanceRequestByIdWithWorker(id);
+    if (!detail) {
+        notFound();
+    }
+
+    return (
+        <FormPageLayout
+            title="Advance request"
+            subtitle={`Summary for worker ${detail.request.workerName}`}>
+            <AdvanceStepProgress
+                className="print:hidden"
+                advanceRequestId={id}
+                activeStep={2}
+            />
+
+            <section className="min-h-[calc(100vh-10rem)] print:min-h-0">
+                <AdvanceSummaryCapture
+                    advanceRequestId={id}
+                    workerName={detail.request.workerName}
+                    amountRequested={detail.request.amountRequested}
+                    requestDate={detail.request.requestDate}>
+                    <AdvancePrintable detail={detail} />
+                </AdvanceSummaryCapture>
+            </section>
+        </FormPageLayout>
+    );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -134,7 +134,8 @@
     html,
     body,
     main,
-    .printable-payroll {
+    .printable-payroll,
+    .printable-advance {
         background: white !important;
     }
 


### PR DESCRIPTION
## Summary
- split advance detail into dedicated breakdown and summary routes
- add a two-step progress card and printable `ADVANCE REQUEST` summary view
- add Playwright-backed `/api/advance/[id]/pdf` export and print styling support

## Test plan
- [ ] open `/dashboard/advance/[id]/breakdown` and confirm step progress appears above advance information
- [ ] navigate to `/dashboard/advance/[id]/summary` and confirm printable summary renders correctly
- [ ] click **Download PDF** and verify filename format: `{workerName} - Advance - $amount - dd_mm_yyyy.pdf`
- [ ] verify `/dashboard/advance/[id]` redirects to `/dashboard/advance/[id]/breakdown`

Made with [Cursor](https://cursor.com)