### PR TITLE
fix(payroll): prevent duplicate settle and auto-download triggers

### DIFF
--- a/app/dashboard/payroll/[id]/payroll-step-progress.tsx
+++ b/app/dashboard/payroll/[id]/payroll-step-progress.tsx
@@ -38,6 +38,7 @@ export function PayrollStepProgress({
     const [open, setOpen] = React.useState(false);
     const [pending, setPending] = React.useState(false);
     const [error, setError] = React.useState<string | null>(null);
+    const settleInFlightRef = React.useRef(false);
     const isSettled = payrollStatus === "Settled";
 
     const steps: StepProgressItem[] = [
@@ -54,19 +55,26 @@ export function PayrollStepProgress({
     ];
 
     async function handleSettle() {
+        if (settleInFlightRef.current) return;
+
+        settleInFlightRef.current = true;
         setError(null);
         setPending(true);
 
-        const result = await settlePayroll(payrollId);
+        try {
+            const result = await settlePayroll(payrollId);
 
-        setPending(false);
-        if (result?.error) {
-            setError(result.error);
-            return;
+            if (result?.error) {
+                setError(result.error);
+                return;
+            }
+
+            setOpen(false);
+            router.push(`/dashboard/payroll/${payrollId}/summary?download=1`);
+        } finally {
+            settleInFlightRef.current = false;
+            setPending(false);
         }
-
-        setOpen(false);
-        router.push(`/dashboard/payroll/${payrollId}/summary?download=1`);
     }
 
     const finalAction = isSettled ? (

--- a/components/ui/summary-capture.tsx
+++ b/components/ui/summary-capture.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { Download } from "lucide-react";
 import { useRouter, useSearchParams } from "next/navigation";
 
@@ -16,6 +16,12 @@ interface SummaryCaptureProps {
     downloadClassName?: string;
 }
 
+type DownloadTriggerSource = "auto" | "manual";
+
+const AUTO_DOWNLOAD_FAILED_MESSAGE =
+    "Automatic download failed. Use Download PDF to retry.";
+const MANUAL_DOWNLOAD_FAILED_MESSAGE = "Failed to download PDF. Please try again.";
+
 export function removeQueryParam(
     searchParams: URLSearchParams,
     param: string,
@@ -23,6 +29,14 @@ export function removeQueryParam(
     const next = new URLSearchParams(searchParams.toString());
     next.delete(param);
     return next.toString();
+}
+
+function getErrorMessage(error: unknown): string {
+    if (error instanceof Error && error.message) {
+        return error.message;
+    }
+
+    return MANUAL_DOWNLOAD_FAILED_MESSAGE;
 }
 
 export function SummaryCapture({
@@ -34,41 +48,55 @@ export function SummaryCapture({
     downloadClassName,
 }: SummaryCaptureProps) {
     const [isGenerating, setIsGenerating] = useState(false);
+    const [downloadError, setDownloadError] = useState<string | null>(null);
     const router = useRouter();
     const searchParams = useSearchParams();
+    const isGeneratingRef = useRef(false);
+    const consumedAutoDownloadKeyRef = useRef<string | null>(null);
 
-    const handleDownloadPdf = useCallback(async () => {
-        if (isGenerating) return;
+    const handleDownloadPdf = useCallback(
+        async (source: DownloadTriggerSource = "manual") => {
+            if (isGeneratingRef.current) return false;
 
-        setIsGenerating(true);
-        try {
-            await onDownload();
-        } finally {
-            setIsGenerating(false);
-        }
-    }, [isGenerating, onDownload]);
+            isGeneratingRef.current = true;
+            setDownloadError(null);
+            setIsGenerating(true);
+
+            try {
+                await onDownload();
+                return true;
+            } catch (error) {
+                if (source === "auto") {
+                    setDownloadError(AUTO_DOWNLOAD_FAILED_MESSAGE);
+                } else {
+                    setDownloadError(getErrorMessage(error));
+                }
+                return false;
+            } finally {
+                isGeneratingRef.current = false;
+                setIsGenerating(false);
+            }
+        },
+        [onDownload],
+    );
 
     useEffect(() => {
-        if (searchParams.get("download") !== "1") return;
-
-        let cancelled = false;
-
-        async function run() {
-            await handleDownloadPdf();
-            if (cancelled) return;
-
-            const path = window.location.pathname;
-            const qs = removeQueryParam(new URLSearchParams(searchParams.toString()), "download");
-            router.replace(qs ? `${path}?${qs}` : path, { scroll: false });
+        if (searchParams.get("download") !== "1") {
+            consumedAutoDownloadKeyRef.current = null;
+            return;
         }
 
-        requestAnimationFrame(() => {
-            void run();
-        });
+        const path = window.location.pathname;
+        const currentSearch = searchParams.toString();
+        const autoDownloadKey = `${path}?${currentSearch}`;
 
-        return () => {
-            cancelled = true;
-        };
+        if (consumedAutoDownloadKeyRef.current === autoDownloadKey) return;
+        consumedAutoDownloadKeyRef.current = autoDownloadKey;
+
+        const qs = removeQueryParam(new URLSearchParams(currentSearch), "download");
+        router.replace(qs ? `${path}?${qs}` : path, { scroll: false });
+
+        void handleDownloadPdf("auto");
     }, [handleDownloadPdf, searchParams, router]);
 
     return (
@@ -77,11 +105,16 @@ export function SummaryCapture({
                 <Button
                     size="lg"
                     className="h-12 w-full text-base"
-                    onClick={handleDownloadPdf}
+                    onClick={() => {
+                        void handleDownloadPdf("manual");
+                    }}
                     disabled={isGenerating}>
                     <Download className="mr-2 h-4 w-4" />
                     {isGenerating ? generatingLabel : buttonLabel}
                 </Button>
+                {downloadError ? (
+                    <p className="mt-2 text-sm text-destructive">{downloadError}</p>
+                ) : null}
             </div>
 
             <div className={cn("w-full print:bg-white", downloadClassName)}>

--- a/plans/payroll-settle-single-auto-download-plan.md
+++ b/plans/payroll-settle-single-auto-download-plan.md
@@ -1,0 +1,82 @@
+# Plan: Payroll Settle Auto-Download Single-Trigger Fix
+
+> Source PRD: [Issue #42](https://github.com/daniellim922/One-Laundry-Project-Alpha-v1/issues/42)
+
+## Architectural decisions
+
+Durable decisions that apply across all phases:
+
+- **Routes**: Keep current payroll and advance summary routes; continue using `download=1` as the auto-download intent signal on summary navigation.
+- **API boundaries**: Preserve separate contracts for single PDF download and batch ZIP download; do not merge or repurpose these paths.
+- **Schema**: No database schema changes. Existing payroll, timesheet, worker, and advance-request structures remain unchanged.
+- **Key models**: Retain current domain models for Payroll (`Draft` -> `Settled`), summary document download intent, PDF artifact generation, and ZIP batch download request.
+- **Auth and authorization**: Keep session-based auth and existing RBAC checks (`read`/`update`) unchanged.
+- **Behavior contract**: Auto-download intent is consumable and one-shot; manual downloads remain user-driven and repeatable; batch ZIP behavior remains unaffected.
+
+---
+
+## Phase 1: One-Shot Auto-Download Trigger
+
+**User stories**: 1, 2, 6, 7, 8, 13
+
+### What to build
+
+Implement a shared one-shot auto-download flow for summary pages that consumes the auto-download intent once and prevents duplicate triggers caused by effect replay, re-render timing, or navigation-side races.
+
+### Acceptance criteria
+
+- [ ] Entering a summary page with `download=1` triggers at most one automatic PDF download attempt.
+- [ ] Auto-download intent is consumed from the URL during the same navigation cycle.
+- [ ] Effect replay or dependency updates do not trigger a second automatic download attempt.
+- [ ] Shared summary behavior is consistent across payroll and advance summary pages.
+
+---
+
+## Phase 2: Auto-Download Failure + Manual Recovery
+
+**User stories**: 3, 4, 5, 9, 10
+
+### What to build
+
+Add explicit failure handling for auto-download attempts and preserve manual download as the primary recovery path, without introducing automatic retries.
+
+### Acceptance criteria
+
+- [ ] Failed auto-download shows an inline, non-blocking error state.
+- [ ] Failed auto-download does not loop or auto-retry once the intent has been consumed.
+- [ ] Manual download remains available after both successful and failed auto-download attempts.
+- [ ] Users can manually download repeatedly, with duplicate in-flight clicks suppressed while generation is pending.
+
+---
+
+## Phase 3: Settle Submit Hardening
+
+**User stories**: 11, 12
+
+### What to build
+
+Harden settle confirmation behavior against duplicate submissions so one user settlement action maps to one settle flow and one downstream auto-download intent.
+
+### Acceptance criteria
+
+- [ ] Rapid or repeated settle-confirm interactions during pending state do not produce duplicate settle submissions.
+- [ ] Successful settlement still transitions to summary with the existing one-shot auto-download intent behavior.
+- [ ] Existing non-draft/error outcomes remain intact and do not introduce unintended navigation changes.
+
+---
+
+## Phase 4: Regression Safety Net (Deterministic Tests)
+
+**User stories**: 14, 15, 16, 17, 18, 19, 20
+
+### What to build
+
+Add deterministic automated tests that validate one-shot auto-download semantics, manual retry behavior, settle guard resilience, and strict non-regression for ZIP batch download separation.
+
+### Acceptance criteria
+
+- [ ] Tests verify exactly one auto-download invocation per `download=1` trigger.
+- [ ] Tests verify intent consumption and no duplicate auto-download on effect replay conditions.
+- [ ] Tests verify manual download remains repeatable and recoverable after auto-download failure.
+- [ ] Tests verify settle confirmation guard prevents duplicate submission behavior.
+- [ ] Tests verify batch ZIP download workflow remains behaviorally unchanged.

--- a/test/unit/payroll-step-progress.test.tsx
+++ b/test/unit/payroll-step-progress.test.tsx
@@ -1,0 +1,104 @@
+/** @vitest-environment jsdom */
+
+import React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+const mocks = vi.hoisted(() => ({
+    push: vi.fn(),
+    settlePayroll: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+    useRouter: () => ({
+        push: mocks.push,
+    }),
+}));
+
+vi.mock("@/components/ui/step-progress-panel", () => ({
+    StepProgressPanel: ({
+        finalAction,
+    }: {
+        finalAction?: { content: React.ReactNode };
+    }) => <div>{finalAction?.content ?? null}</div>,
+}));
+
+vi.mock("@/app/dashboard/payroll/actions", () => ({
+    settlePayroll: (...args: unknown[]) => mocks.settlePayroll(...args),
+}));
+
+import { PayrollStepProgress } from "@/app/dashboard/payroll/[id]/payroll-step-progress";
+
+function createDeferred<T>() {
+    let resolve!: (value: T | PromiseLike<T>) => void;
+    let reject!: (reason?: unknown) => void;
+    const promise = new Promise<T>((res, rej) => {
+        resolve = res;
+        reject = rej;
+    });
+    return { promise, resolve, reject };
+}
+
+describe("PayrollStepProgress", () => {
+    afterEach(() => {
+        cleanup();
+    });
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it("prevents duplicate settle submissions on rapid confirm clicks", async () => {
+        const settleDeferred = createDeferred<{ success: true }>();
+        mocks.settlePayroll.mockImplementationOnce(() => settleDeferred.promise);
+
+        render(
+            <PayrollStepProgress
+                payrollId="payroll-1"
+                payrollStatus="Draft"
+                activeStep={2}
+            />,
+        );
+
+        fireEvent.click(screen.getByRole("button", { name: "Settle" }));
+        const confirmButton = screen.getByRole("button", {
+            name: "Yes, settle",
+        });
+        fireEvent.click(confirmButton);
+        fireEvent.click(confirmButton);
+
+        expect(mocks.settlePayroll).toHaveBeenCalledTimes(1);
+        expect(mocks.settlePayroll).toHaveBeenCalledWith("payroll-1");
+
+        settleDeferred.resolve({ success: true });
+
+        await waitFor(() => {
+            expect(mocks.push).toHaveBeenCalledWith(
+                "/dashboard/payroll/payroll-1/summary?download=1",
+            );
+        });
+        expect(mocks.push).toHaveBeenCalledTimes(1);
+    });
+
+    it("keeps existing error behavior when settle fails", async () => {
+        mocks.settlePayroll.mockResolvedValueOnce({
+            error: "Only Draft payrolls can be settled",
+        });
+
+        render(
+            <PayrollStepProgress
+                payrollId="payroll-1"
+                payrollStatus="Draft"
+                activeStep={2}
+            />,
+        );
+
+        fireEvent.click(screen.getByRole("button", { name: "Settle" }));
+        fireEvent.click(screen.getByRole("button", { name: "Yes, settle" }));
+
+        expect(
+            await screen.findByText("Only Draft payrolls can be settled"),
+        ).toBeTruthy();
+        expect(mocks.push).not.toHaveBeenCalled();
+    });
+});

--- a/test/unit/summary-capture.test.tsx
+++ b/test/unit/summary-capture.test.tsx
@@ -1,0 +1,144 @@
+/** @vitest-environment jsdom */
+
+import React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+const mocks = vi.hoisted(() => ({
+    replace: vi.fn(),
+    searchParamsString: "",
+}));
+
+vi.mock("next/navigation", () => ({
+    useRouter: () => ({
+        replace: mocks.replace,
+    }),
+    useSearchParams: () => new URLSearchParams(mocks.searchParamsString),
+}));
+
+import { SummaryCapture } from "@/components/ui/summary-capture";
+
+function createDeferred<T>() {
+    let resolve!: (value: T | PromiseLike<T>) => void;
+    let reject!: (reason?: unknown) => void;
+    const promise = new Promise<T>((res, rej) => {
+        resolve = res;
+        reject = rej;
+    });
+    return { promise, resolve, reject };
+}
+
+describe("SummaryCapture", () => {
+    afterEach(() => {
+        cleanup();
+    });
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mocks.searchParamsString = "";
+        window.history.replaceState(
+            null,
+            "",
+            "/dashboard/payroll/pay-1/summary",
+        );
+    });
+
+    it("auto-downloads once for a single download=1 intent and consumes it", async () => {
+        mocks.searchParamsString = "download=1&mode=voucher";
+        window.history.replaceState(
+            null,
+            "",
+            "/dashboard/payroll/pay-1/summary?download=1&mode=voucher",
+        );
+
+        const onDownload = vi.fn().mockResolvedValue(undefined);
+
+        render(
+            <React.StrictMode>
+                <SummaryCapture onDownload={onDownload}>
+                    <div>content</div>
+                </SummaryCapture>
+            </React.StrictMode>,
+        );
+
+        await waitFor(() => {
+            expect(onDownload).toHaveBeenCalledTimes(1);
+        });
+        expect(mocks.replace).toHaveBeenCalledWith(
+            "/dashboard/payroll/pay-1/summary?mode=voucher",
+            { scroll: false },
+        );
+    });
+
+    it("shows inline auto-download failure and keeps manual recovery available", async () => {
+        mocks.searchParamsString = "download=1";
+        window.history.replaceState(
+            null,
+            "",
+            "/dashboard/payroll/pay-1/summary?download=1",
+        );
+
+        const onDownload = vi
+            .fn()
+            .mockRejectedValueOnce(new Error("PDF download failed (500)"))
+            .mockResolvedValueOnce(undefined);
+
+        render(
+            <SummaryCapture onDownload={onDownload}>
+                <div>content</div>
+            </SummaryCapture>,
+        );
+
+        await waitFor(() => {
+            expect(onDownload).toHaveBeenCalledTimes(1);
+        });
+
+        expect(
+            await screen.findByText(
+                "Automatic download failed. Use Download PDF to retry.",
+            ),
+        ).toBeTruthy();
+        expect(screen.getByRole("button", { name: "Download PDF" })).toBeTruthy();
+
+        fireEvent.click(screen.getByRole("button", { name: "Download PDF" }));
+
+        await waitFor(() => {
+            expect(onDownload).toHaveBeenCalledTimes(2);
+        });
+    });
+
+    it("suppresses duplicate in-flight manual clicks and allows repeated manual downloads", async () => {
+        const firstDownload = createDeferred<void>();
+        const onDownload = vi
+            .fn()
+            .mockImplementationOnce(() => firstDownload.promise)
+            .mockResolvedValueOnce(undefined);
+
+        render(
+            <SummaryCapture onDownload={onDownload}>
+                <div>content</div>
+            </SummaryCapture>,
+        );
+
+        const downloadButton = screen.getByRole("button", {
+            name: "Download PDF",
+        });
+
+        fireEvent.click(downloadButton);
+        fireEvent.click(downloadButton);
+
+        expect(onDownload).toHaveBeenCalledTimes(1);
+
+        firstDownload.resolve();
+        await waitFor(() => {
+            expect(downloadButton.hasAttribute("disabled")).toBe(false);
+        });
+
+        fireEvent.click(downloadButton);
+
+        await waitFor(() => {
+            expect(onDownload).toHaveBeenCalledTimes(2);
+        });
+    });
+});
+


### PR DESCRIPTION
## Summary
- prevent duplicate `settlePayroll` submissions by adding an in-flight guard in payroll settle flow
- harden `SummaryCapture` auto-download behavior to consume `download=1` once and block duplicate in-flight triggers
- add inline error messaging for failed auto-download/manual download attempts
- add unit coverage for settle de-duplication and one-shot/retryable summary download behavior
- include implementation plan document for payroll auto-download single-trigger fix

## Testing
- `npx vitest run test/unit/payroll-step-progress.test.tsx test/unit/summary-capture.test.tsx`