### PR TITLE
feat(payroll): revert preview detail tables and larger dialog

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,87 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project
+
+Workforce payroll and back-office operations app for a laundry business.
+Bounded context: **workers, employment, timesheets, payroll, salary advances, expenses, IAM**.
+Domain glossary: `.cursor/UBIQUITOUS_LANGUAGE.md` — read it before touching payroll or advance logic.
+
+## Commands
+
+```bash
+npm install               # install deps
+npm run dev               # dev server (Turbopack)
+npm run build             # production build
+npm run lint              # ESLint (flat config, core-web-vitals + TS)
+npm run test              # all Vitest tests (unit + integration)
+npm run test:unit         # unit tests only
+npm run test:e2e          # Playwright E2E (auto-starts dev server)
+npm run db:generate       # generate Drizzle migration
+npm run db:migrate        # run migrations
+npm run db:seed           # push schema + seed
+npm run db:studio         # Drizzle Studio GUI
+npm run db:wipe           # wipe database
+```
+
+### Single-file validation
+
+```bash
+npx tsc --noEmit                       # typecheck entire project
+npx eslint <file>                      # lint a single file
+npx vitest run test/unit/<file>        # run one unit test file
+npx vitest run test/integration/<file> # run one integration test file
+```
+
+## Stack
+
+Next.js 16 (App Router, React 19, React Compiler) · TypeScript 5 · PostgreSQL + Drizzle ORM 0.45.1 · better-auth (session-based, username plugin) · shadcn/ui (new-york) · Tailwind CSS v4 · TanStack React Table v8 · react-hook-form + Zod · Recharts · Vitest + Playwright.
+
+## Architecture
+
+- **Server components by default.** Add `"use client"` only for interactive pieces (forms, tables, dropdowns).
+- **Server actions** live in `actions.ts` co-located with each feature route under `app/dashboard/<feature>/`. They start with `"use server"`, validate from `FormData`, return `{ success, id? } | { error }`, and call `revalidatePath` after mutations.
+- **Authorization** is feature-based RBAC. Server components call `requirePermission(featureName, action)` (redirects on fail). API routes use `auth.api.getSession` + `checkPermission`. Feature names: `"Home"`, `"Workers"`, `"Timesheet"`, `"Payroll"`, `"Advance"`, `"Expenses"`, `"IAM (Identity and Access Management)"`.
+- **Forms** use react-hook-form + `zodResolver` for complex cases, or plain `useState` + `FormData` for simple ones. All form pages use `FormPageLayout` (back button, title, subtitle, optional actions slot).
+- **Data tables** use the shared `DataTable` from `components/data-table/`. Columns are defined in `columns.tsx` next to the route. Use `createSortableHeader`, `createBadgeCell`, `createActionsColumn` from `column-builders.tsx`.
+- **Database tables** use `pgTable("snake_case", { ... })` with UUID PKs. Enums are `text(..., { enum: [...] as const })` aligned with `types/status.ts`. Types exported via `$inferSelect` / `$inferInsert`.
+
+## Key file locations
+
+| What | Where |
+|---|---|
+| Route pages + server actions | `app/dashboard/<feature>/` |
+| Shared UI primitives (read-only) | `components/ui/` |
+| Data table components | `components/data-table/` |
+| Form page shell | `components/form-page-layout.tsx` |
+| DB, auth, Tailwind `cn` | `lib/db.ts`, `lib/auth.ts`, `lib/auth-client.ts`, `lib/utils.ts` |
+| RBAC | `utils/permissions/permissions.ts`, `utils/permissions/require-permission.ts` |
+| Payroll calculations | `utils/payroll/payroll-utils.ts`, `utils/payroll/parse-attendrecord.ts` |
+| Domain status enums + badge tones | `types/status.ts`, `types/badge-tones.ts` |
+| All Drizzle table schemas | `db/tables/` (re-exported via `db/schema.ts`) |
+| Seeds & migrations | `db/seed/`, `drizzle/` |
+
+## Testing
+
+- **Unit/integration** — Vitest, node environment, `test/unit/*.test.ts` and `test/integration/*.test.ts`.
+- **E2E** — Playwright (Chromium), `test/e2e/*.spec.ts`. Auth setup persists to `test/e2e/.auth/user.json`.
+- **Fixtures** in `test/fixtures/`, output in `test/results/`.
+- E2E worker tests are deterministic and assume seeded data. Run `npm run db:seed` first.
+
+## Domain terminology (critical)
+
+- **Settled** applies only to **Payroll**, never to Advances. Advances use **Advance Paid** / **Advance Loan**.
+- **Installment** repayment statuses: **Installment Loan** (outstanding) / **Installment Paid** (recovered).
+- **Timesheet** settlement: **Timesheet Unpaid** / **Timesheet Paid** (always prefixed to disambiguate).
+- **Reopen** reverses a Settled payroll: timesheets revert to Timesheet Unpaid, advance installments revert to Installment Loan.
+- **Pay periods** for the same Worker must not overlap across Payroll runs.
+- **Workers** are who we pay; **Users** are who log in. A User manages Workers but is not necessarily one.
+
+## Rules
+
+- **Never edit default shadcn/ui components** in `components/ui/`. Compose or wrap them in new files instead. Use `npx shadcn@latest add <component>` for upstream updates.
+- Use `cn()` from `lib/utils.ts` for conditional Tailwind classes.
+- Co-locate feature forms (`<feature>-form.tsx`) and table columns (`columns.tsx`) next to their route.
+- Use `revalidatePath` after server action mutations.
+- Use status unions from `types/status.ts` and badge tone maps from `types/badge-tones.ts`.

--- a/app/dashboard/payroll/[id]/payroll-step-progress.tsx
+++ b/app/dashboard/payroll/[id]/payroll-step-progress.tsx
@@ -2,12 +2,14 @@
 
 import * as React from "react";
 import { useRouter } from "next/navigation";
+import { ChevronDown, Loader2 } from "lucide-react";
 
 import {
     StepProgressPanel,
     type StepProgressItem,
 } from "@/components/ui/step-progress-panel";
 import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
 import {
     Dialog,
     DialogClose,
@@ -18,8 +20,30 @@ import {
     DialogTitle,
     DialogTrigger,
 } from "@/components/ui/dialog";
+import {
+    Table,
+    TableBody,
+    TableCell,
+    TableHead,
+    TableHeader,
+    TableRow,
+} from "@/components/ui/table";
 
-import { settlePayroll } from "../actions";
+import {
+    settlePayroll,
+    revertPayroll,
+    getRevertPreview,
+    type RevertPreviewRow,
+} from "../actions";
+import { cn } from "@/lib/utils";
+import {
+    payrollStatusBadgeTone,
+    timesheetPaymentStatusBadgeTone,
+    installmentToneClassName,
+    advanceLoanToneClassName,
+} from "@/types/badge-tones";
+import { localDateDmy } from "@/utils/time/local-iso-date";
+import { localTimeHm } from "@/utils/time/local-time";
 
 interface PayrollStepProgressProps {
     className?: string;
@@ -39,7 +63,41 @@ export function PayrollStepProgress({
     const [pending, setPending] = React.useState(false);
     const [error, setError] = React.useState<string | null>(null);
     const settleInFlightRef = React.useRef(false);
+
+    const [revertOpen, setRevertOpen] = React.useState(false);
+    const [revertPending, setRevertPending] = React.useState(false);
+    const [revertError, setRevertError] = React.useState<string | null>(null);
+    const revertInFlightRef = React.useRef(false);
+
+    const [previewLoading, setPreviewLoading] = React.useState(false);
+    const [previewData, setPreviewData] = React.useState<
+        RevertPreviewRow[] | null
+    >(null);
+    const [previewError, setPreviewError] = React.useState<string | null>(null);
+
     const isSettled = payrollStatus === "Settled";
+
+    React.useEffect(() => {
+        if (!revertOpen) {
+            setPreviewData(null);
+            setPreviewError(null);
+            return;
+        }
+        let cancelled = false;
+        setPreviewLoading(true);
+        getRevertPreview(payrollId).then((result) => {
+            if (cancelled) return;
+            if ("error" in result) {
+                setPreviewError(result.error);
+            } else {
+                setPreviewData(result.data);
+            }
+            setPreviewLoading(false);
+        });
+        return () => {
+            cancelled = true;
+        };
+    }, [revertOpen, payrollId]);
 
     const steps: StepProgressItem[] = [
         {
@@ -77,14 +135,91 @@ export function PayrollStepProgress({
         }
     }
 
+    async function handleRevert() {
+        if (revertInFlightRef.current) return;
+
+        revertInFlightRef.current = true;
+        setRevertError(null);
+        setRevertPending(true);
+
+        try {
+            const result = await revertPayroll(payrollId);
+
+            if (result?.error) {
+                setRevertError(result.error);
+                return;
+            }
+
+            setRevertOpen(false);
+            router.push(`/dashboard/payroll/${payrollId}/breakdown`);
+        } finally {
+            revertInFlightRef.current = false;
+            setRevertPending(false);
+        }
+    }
+
     const finalAction = isSettled ? (
-        <Button
-            type="button"
-            variant="destructive"
-            size="sm"
-            onClick={() => {}}>
-            Revert
-        </Button>
+        <Dialog
+            open={revertOpen}
+            onOpenChange={(nextOpen) => {
+                setRevertOpen(nextOpen);
+                if (!nextOpen) setRevertError(null);
+            }}>
+            <DialogTrigger asChild>
+                <Button
+                    type="button"
+                    variant="destructive"
+                    size="sm"
+                    disabled={revertPending}
+                    className="cursor-pointer">
+                    Revert
+                </Button>
+            </DialogTrigger>
+            <DialogContent className="[&_button]:cursor-pointer flex max-h-[min(95vh,1100px)] flex-col gap-4 sm:max-w-6xl">
+                <DialogHeader className="shrink-0">
+                    <DialogTitle>Confirm revert</DialogTitle>
+                    <DialogDescription>
+                        The following changes will be applied:
+                    </DialogDescription>
+                </DialogHeader>
+                <div className="min-h-0 flex-1 overflow-y-auto">
+                    {previewLoading ? (
+                        <div className="flex items-center gap-2 py-4">
+                            <Loader2 className="h-4 w-4 animate-spin" />
+                            <span className="text-sm text-muted-foreground">
+                                Loading preview...
+                            </span>
+                        </div>
+                    ) : previewError ? (
+                        <p className="text-sm text-destructive">{previewError}</p>
+                    ) : previewData ? (
+                        <RevertPreviewTable rows={previewData} />
+                    ) : null}
+                </div>
+                {revertError ? (
+                    <p className="shrink-0 text-sm text-destructive">
+                        {revertError}
+                    </p>
+                ) : null}
+                <DialogFooter className="shrink-0">
+                    <DialogClose asChild>
+                        <Button
+                            type="button"
+                            variant="outline"
+                            disabled={revertPending}>
+                            Cancel
+                        </Button>
+                    </DialogClose>
+                    <Button
+                        type="button"
+                        variant="destructive"
+                        disabled={revertPending}
+                        onClick={handleRevert}>
+                        {revertPending ? "Reverting..." : "Yes, revert"}
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
     ) : (
         <Dialog
             open={open}
@@ -140,5 +275,199 @@ export function PayrollStepProgress({
             activeStep={activeStep}
             finalAction={{ id: 3, content: finalAction }}
         />
+    );
+}
+
+const statusToneMap: Record<string, string> = {
+    ...payrollStatusBadgeTone,
+    ...timesheetPaymentStatusBadgeTone,
+    ...installmentToneClassName,
+    ...advanceLoanToneClassName,
+};
+
+function revertPreviewRowIsExpandable(row: RevertPreviewRow): boolean {
+    return (
+        (row.timesheetLines?.length ?? 0) > 0 ||
+        (row.advanceInstallmentLines?.length ?? 0) > 0
+    );
+}
+
+function RevertPreviewExpandedLines({ row }: { row: RevertPreviewRow }) {
+    if (row.timesheetLines?.length) {
+        return (
+            <Table className="text-sm">
+                <TableHeader>
+                    <TableRow>
+                        <TableHead>Date in</TableHead>
+                        <TableHead>Date out</TableHead>
+                        <TableHead>Time in</TableHead>
+                        <TableHead>Time out</TableHead>
+                        <TableHead>Hours</TableHead>
+                    </TableRow>
+                </TableHeader>
+                <TableBody>
+                    {row.timesheetLines.map((line) => (
+                        <TableRow key={line.id}>
+                            <TableCell>{localDateDmy(line.dateIn)}</TableCell>
+                            <TableCell>{localDateDmy(line.dateOut)}</TableCell>
+                            <TableCell>{localTimeHm(line.timeIn)}</TableCell>
+                            <TableCell>{localTimeHm(line.timeOut)}</TableCell>
+                            <TableCell>
+                                {Number(line.hours).toFixed(2)}
+                            </TableCell>
+                        </TableRow>
+                    ))}
+                </TableBody>
+            </Table>
+        );
+    }
+
+    if (row.advanceInstallmentLines?.length) {
+        return (
+            <Table className="text-sm">
+                <TableHeader>
+                    <TableRow>
+                        <TableHead>Repayment date</TableHead>
+                        <TableHead>Amount</TableHead>
+                    </TableRow>
+                </TableHeader>
+                <TableBody>
+                    {row.advanceInstallmentLines.map((line) => (
+                        <TableRow key={line.id}>
+                            <TableCell>
+                                {line.repaymentDate
+                                    ? localDateDmy(line.repaymentDate)
+                                    : "—"}
+                            </TableCell>
+                            <TableCell>{`$${line.amount}`}</TableCell>
+                        </TableRow>
+                    ))}
+                </TableBody>
+            </Table>
+        );
+    }
+
+    return null;
+}
+
+function RevertPreviewTable({ rows }: { rows: RevertPreviewRow[] }) {
+    const [expandedRowNames, setExpandedRowNames] = React.useState<
+        Record<string, boolean>
+    >({});
+
+    function toggleRowExpanded(name: string) {
+        setExpandedRowNames((prev) => ({
+            ...prev,
+            [name]: !prev[name],
+        }));
+    }
+
+    return (
+        <Table>
+            <TableHeader>
+                <TableRow>
+                    <TableHead>Name</TableHead>
+                    <TableHead>Current Status</TableHead>
+                    <TableHead>Future Status</TableHead>
+                </TableRow>
+            </TableHeader>
+            <TableBody>
+                {rows.map((row) => {
+                    const badges = (
+                        <>
+                            <TableCell>
+                                <Badge
+                                    variant="secondary"
+                                    className={cn(
+                                        statusToneMap[row.currentStatus],
+                                    )}>
+                                    {row.currentStatus}
+                                </Badge>
+                            </TableCell>
+                            <TableCell>
+                                <Badge
+                                    variant="secondary"
+                                    className={cn(
+                                        statusToneMap[row.futureStatus],
+                                    )}>
+                                    {row.futureStatus}
+                                </Badge>
+                            </TableCell>
+                        </>
+                    );
+
+                    if (revertPreviewRowIsExpandable(row)) {
+                        const expanded = !!expandedRowNames[row.name];
+                        return (
+                            <React.Fragment key={row.name}>
+                                <TableRow>
+                                    <TableCell className="font-medium">
+                                        <button
+                                            type="button"
+                                            aria-expanded={expanded}
+                                            onClick={() =>
+                                                toggleRowExpanded(row.name)
+                                            }
+                                            className="flex cursor-pointer items-center gap-2 text-left underline-offset-4 hover:underline">
+                                            <ChevronDown
+                                                className={cn(
+                                                    "size-4 shrink-0 transition-transform",
+                                                    expanded && "rotate-180",
+                                                )}
+                                            />
+                                            <span>{row.name}</span>
+                                        </button>
+                                    </TableCell>
+                                    <TableCell>
+                                        <Badge
+                                            variant="secondary"
+                                            className={cn(
+                                                statusToneMap[
+                                                    row.currentStatus
+                                                ],
+                                            )}>
+                                            {row.currentStatus}
+                                        </Badge>
+                                    </TableCell>
+                                    <TableCell>
+                                        <Badge
+                                            variant="secondary"
+                                            className={cn(
+                                                statusToneMap[
+                                                    row.futureStatus
+                                                ],
+                                            )}>
+                                            {row.futureStatus}
+                                        </Badge>
+                                    </TableCell>
+                                </TableRow>
+                                {expanded ? (
+                                    <TableRow className="hover:bg-transparent">
+                                        <TableCell
+                                            colSpan={3}
+                                            className="p-0">
+                                            <div className="max-h-96 overflow-y-auto border-t bg-muted/40 px-4 py-3">
+                                                <RevertPreviewExpandedLines
+                                                    row={row}
+                                                />
+                                            </div>
+                                        </TableCell>
+                                    </TableRow>
+                                ) : null}
+                            </React.Fragment>
+                        );
+                    }
+
+                    return (
+                        <TableRow key={row.name}>
+                            <TableCell className="font-medium">
+                                {row.name}
+                            </TableCell>
+                            {badges}
+                        </TableRow>
+                    );
+                })}
+            </TableBody>
+        </Table>
     );
 }

--- a/app/dashboard/payroll/actions.ts
+++ b/app/dashboard/payroll/actions.ts
@@ -939,6 +939,177 @@ export async function settlePayroll(payrollId: string) {
     return { success: true };
 }
 
+async function revertPayrollInTx(
+    tx: DbTransaction,
+    payroll: {
+        id: string;
+        workerId: string;
+        periodStart: string;
+        periodEnd: string;
+    },
+    now: Date,
+) {
+    type AdvanceInPeriodRow = {
+        id: string;
+        advanceRequestId: string;
+        status: "Installment Loan" | "Installment Paid";
+    };
+    type RequestAdvanceRow = {
+        advanceRequestId: string;
+        status: "Installment Loan" | "Installment Paid";
+    };
+
+    await tx
+        .update(payrollTable)
+        .set({
+            status: "Draft",
+            updatedAt: now,
+        })
+        .where(eq(payrollTable.id, payroll.id));
+
+    const advancesInPeriod: AdvanceInPeriodRow[] = await tx
+        .select({
+            id: advanceTable.id,
+            advanceRequestId: advanceTable.advanceRequestId,
+            status: advanceTable.status,
+        })
+        .from(advanceTable)
+        .innerJoin(
+            advanceRequestTable,
+            eq(advanceTable.advanceRequestId, advanceRequestTable.id),
+        )
+        .where(
+            and(
+                eq(advanceRequestTable.workerId, payroll.workerId),
+                gte(advanceTable.repaymentDate, payroll.periodStart),
+                lte(advanceTable.repaymentDate, payroll.periodEnd),
+            ),
+        );
+
+    const installmentPaidIds = advancesInPeriod
+        .filter((advance) => advance.status === "Installment Paid")
+        .map((advance) => advance.id);
+
+    if (installmentPaidIds.length > 0) {
+        await tx
+            .update(advanceTable)
+            .set({
+                status: "Installment Loan",
+                updatedAt: now,
+            })
+            .where(inArray(advanceTable.id, installmentPaidIds));
+    }
+
+    const requestIds: string[] = Array.from(
+        new Set(advancesInPeriod.map((advance) => advance.advanceRequestId)),
+    );
+
+    if (requestIds.length > 0) {
+        const requestAdvances: RequestAdvanceRow[] = await tx
+            .select({
+                advanceRequestId: advanceTable.advanceRequestId,
+                status: advanceTable.status,
+            })
+            .from(advanceTable)
+            .where(inArray(advanceTable.advanceRequestId, requestIds));
+
+        const byRequestId = requestAdvances.reduce(
+            (acc, row) => {
+                if (!acc[row.advanceRequestId]) acc[row.advanceRequestId] = [];
+                acc[row.advanceRequestId]!.push({ status: row.status });
+                return acc;
+            },
+            {} as Record<
+                string,
+                Array<{ status: "Installment Loan" | "Installment Paid" }>
+            >,
+        );
+
+        const fullyPaidRequestIds = requestIds.filter((requestId: string) => {
+            const advances = byRequestId[requestId] ?? [];
+            return (
+                advances.length > 0 &&
+                advances.every((a) => a.status === "Installment Paid")
+            );
+        });
+
+        const notFullyPaidRequestIds = requestIds.filter(
+            (requestId: string) => !fullyPaidRequestIds.includes(requestId),
+        );
+
+        if (fullyPaidRequestIds.length > 0) {
+            await tx
+                .update(advanceRequestTable)
+                .set({
+                    status: "Advance Paid",
+                    updatedAt: now,
+                })
+                .where(inArray(advanceRequestTable.id, fullyPaidRequestIds));
+        }
+
+        if (notFullyPaidRequestIds.length > 0) {
+            await tx
+                .update(advanceRequestTable)
+                .set({
+                    status: "Advance Loan",
+                    updatedAt: now,
+                })
+                .where(inArray(advanceRequestTable.id, notFullyPaidRequestIds));
+        }
+    }
+
+    await tx
+        .update(timesheetTable)
+        .set({
+            status: "Timesheet Unpaid",
+            updatedAt: now,
+        })
+        .where(
+            and(
+                eq(timesheetTable.workerId, payroll.workerId),
+                gte(timesheetTable.dateIn, payroll.periodStart),
+                lte(timesheetTable.dateOut, payroll.periodEnd),
+                eq(timesheetTable.status, "Timesheet Paid"),
+            ),
+        );
+}
+
+export async function revertPayroll(payrollId: string) {
+    await requirePermission("Payroll", "update");
+
+    const [payroll] = await db
+        .select()
+        .from(payrollTable)
+        .where(eq(payrollTable.id, payrollId))
+        .limit(1);
+
+    if (!payroll) return { error: "Payroll not found" };
+    if (payroll.status !== "Settled") {
+        return { error: "Only Settled payrolls can be reverted" };
+    }
+
+    const now = new Date();
+
+    try {
+        await db.transaction(async (tx) => {
+            await revertPayrollInTx(tx, payroll, now);
+        });
+    } catch (error) {
+        console.error("Error reverting payroll", error);
+        return { error: "Failed to revert payroll" };
+    }
+
+    revalidatePath(`/dashboard/payroll/${payrollId}/breakdown`);
+    revalidatePath(`/dashboard/payroll/${payrollId}/summary`);
+    revalidatePath("/dashboard/payroll");
+    revalidatePath("/dashboard/payroll/all");
+    revalidatePath("/dashboard/advance");
+    revalidatePath("/dashboard/advance/all");
+    revalidatePath("/dashboard/timesheet");
+    revalidatePath("/dashboard/timesheet/all");
+    return { success: true };
+}
+
 class SettleDraftPayrollsValidationError extends Error {
     readonly code: "NOT_FOUND" | "NOT_DRAFT";
 
@@ -1172,4 +1343,190 @@ export async function updateVoucherDays(input: {
     revalidatePath("/dashboard/payroll");
     revalidatePath("/dashboard/payroll/all");
     return { success: true };
+}
+
+export type RevertPreviewTimesheetLine = {
+    id: string;
+    dateIn: string;
+    dateOut: string;
+    timeIn: string;
+    timeOut: string;
+    hours: number;
+};
+
+export type RevertPreviewAdvanceInstallmentLine = {
+    id: string;
+    amount: number;
+    repaymentDate: string | null;
+};
+
+export type RevertPreviewRow = {
+    name: string;
+    currentStatus: string;
+    futureStatus: string;
+    timesheetLines?: RevertPreviewTimesheetLine[];
+    advanceInstallmentLines?: RevertPreviewAdvanceInstallmentLine[];
+};
+
+export async function getRevertPreview(
+    payrollId: string,
+): Promise<{ data: RevertPreviewRow[] } | { error: string }> {
+    await requirePermission("Payroll", "read");
+
+    const [payroll] = await db
+        .select()
+        .from(payrollTable)
+        .where(eq(payrollTable.id, payrollId))
+        .limit(1);
+
+    if (!payroll) return { error: "Payroll not found" };
+    if (payroll.status !== "Settled") {
+        return { error: "Only Settled payrolls can be previewed for revert" };
+    }
+
+    const rows: RevertPreviewRow[] = [
+        { name: "Payroll", currentStatus: "Settled", futureStatus: "Draft" },
+    ];
+
+    const timesheets = await db
+        .select({
+            id: timesheetTable.id,
+            dateIn: timesheetTable.dateIn,
+            dateOut: timesheetTable.dateOut,
+            timeIn: timesheetTable.timeIn,
+            timeOut: timesheetTable.timeOut,
+            hours: timesheetTable.hours,
+        })
+        .from(timesheetTable)
+        .where(
+            and(
+                eq(timesheetTable.workerId, payroll.workerId),
+                gte(timesheetTable.dateIn, payroll.periodStart),
+                lte(timesheetTable.dateOut, payroll.periodEnd),
+                eq(timesheetTable.status, "Timesheet Paid"),
+            ),
+        )
+        .orderBy(asc(timesheetTable.dateIn));
+
+    if (timesheets.length > 0) {
+        rows.push({
+            name: `Timesheets (${timesheets.length})`,
+            currentStatus: "Timesheet Paid",
+            futureStatus: "Timesheet Unpaid",
+            timesheetLines: timesheets.map((t) => ({
+                id: t.id,
+                dateIn: String(t.dateIn),
+                dateOut: String(t.dateOut),
+                timeIn: String(t.timeIn),
+                timeOut: String(t.timeOut),
+                hours: t.hours,
+            })),
+        });
+    }
+
+    type AdvanceInPeriodRow = {
+        id: string;
+        advanceRequestId: string;
+        status: "Installment Loan" | "Installment Paid";
+        amount: number;
+        repaymentDate: string | null;
+    };
+
+    const advancesInPeriod: AdvanceInPeriodRow[] = await db
+        .select({
+            id: advanceTable.id,
+            advanceRequestId: advanceTable.advanceRequestId,
+            status: advanceTable.status,
+            amount: advanceTable.amount,
+            repaymentDate: advanceTable.repaymentDate,
+        })
+        .from(advanceTable)
+        .innerJoin(
+            advanceRequestTable,
+            eq(advanceTable.advanceRequestId, advanceRequestTable.id),
+        )
+        .where(
+            and(
+                eq(advanceRequestTable.workerId, payroll.workerId),
+                gte(advanceTable.repaymentDate, payroll.periodStart),
+                lte(advanceTable.repaymentDate, payroll.periodEnd),
+            ),
+        );
+
+    const installmentPaidInPeriod = advancesInPeriod
+        .filter((a) => a.status === "Installment Paid")
+        .sort((a, b) =>
+            String(a.repaymentDate ?? "").localeCompare(
+                String(b.repaymentDate ?? ""),
+            ),
+        );
+
+    if (installmentPaidInPeriod.length > 0) {
+        rows.push({
+            name: `Advance (${installmentPaidInPeriod.length})`,
+            currentStatus: "Installment Paid",
+            futureStatus: "Installment Loan",
+            advanceInstallmentLines: installmentPaidInPeriod.map((a) => ({
+                id: a.id,
+                amount: a.amount,
+                repaymentDate: a.repaymentDate,
+            })),
+        });
+    }
+
+    const requestIds = Array.from(
+        new Set(advancesInPeriod.map((a) => a.advanceRequestId)),
+    );
+
+    if (requestIds.length > 0) {
+        type RequestAdvanceRow = {
+            advanceRequestId: string;
+            status: "Installment Loan" | "Installment Paid";
+        };
+
+        const requestAdvances: RequestAdvanceRow[] = await db
+            .select({
+                advanceRequestId: advanceTable.advanceRequestId,
+                status: advanceTable.status,
+            })
+            .from(advanceTable)
+            .where(inArray(advanceTable.advanceRequestId, requestIds));
+
+        const byRequestId = requestAdvances.reduce(
+            (acc, row) => {
+                if (!acc[row.advanceRequestId]) acc[row.advanceRequestId] = [];
+                acc[row.advanceRequestId]!.push({ status: row.status });
+                return acc;
+            },
+            {} as Record<
+                string,
+                Array<{ status: "Installment Loan" | "Installment Paid" }>
+            >,
+        );
+
+        const installmentPaidRequestIds = new Set(
+            installmentPaidInPeriod.map((a) => a.advanceRequestId),
+        );
+
+        let advanceRequestFlipCount = 0;
+        for (const requestId of requestIds) {
+            const allInstallments = byRequestId[requestId] ?? [];
+            const currentlyAllPaid =
+                allInstallments.length > 0 &&
+                allInstallments.every((a) => a.status === "Installment Paid");
+            if (currentlyAllPaid && installmentPaidRequestIds.has(requestId)) {
+                advanceRequestFlipCount++;
+            }
+        }
+
+        if (advanceRequestFlipCount > 0) {
+            rows.push({
+                name: `Advance Requests (${advanceRequestFlipCount})`,
+                currentStatus: "Advance Paid",
+                futureStatus: "Advance Loan",
+            });
+        }
+    }
+
+    return { data: rows };
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2318,9 +2318,6 @@
             "cpu": [
                 "arm"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -2336,9 +2333,6 @@
             "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
             "cpu": [
                 "arm64"
-            ],
-            "libc": [
-                "glibc"
             ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
@@ -2356,9 +2350,6 @@
             "cpu": [
                 "ppc64"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -2374,9 +2365,6 @@
             "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
             "cpu": [
                 "riscv64"
-            ],
-            "libc": [
-                "glibc"
             ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
@@ -2394,9 +2382,6 @@
             "cpu": [
                 "s390x"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -2412,9 +2397,6 @@
             "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
             "cpu": [
                 "x64"
-            ],
-            "libc": [
-                "glibc"
             ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
@@ -2432,9 +2414,6 @@
             "cpu": [
                 "arm64"
             ],
-            "libc": [
-                "musl"
-            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -2451,9 +2430,6 @@
             "cpu": [
                 "x64"
             ],
-            "libc": [
-                "musl"
-            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -2469,9 +2445,6 @@
             "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
             "cpu": [
                 "arm"
-            ],
-            "libc": [
-                "glibc"
             ],
             "license": "Apache-2.0",
             "optional": true,
@@ -2495,9 +2468,6 @@
             "cpu": [
                 "arm64"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -2519,9 +2489,6 @@
             "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
             "cpu": [
                 "ppc64"
-            ],
-            "libc": [
-                "glibc"
             ],
             "license": "Apache-2.0",
             "optional": true,
@@ -2545,9 +2512,6 @@
             "cpu": [
                 "riscv64"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -2569,9 +2533,6 @@
             "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
             "cpu": [
                 "s390x"
-            ],
-            "libc": [
-                "glibc"
             ],
             "license": "Apache-2.0",
             "optional": true,
@@ -2595,9 +2556,6 @@
             "cpu": [
                 "x64"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -2620,9 +2578,6 @@
             "cpu": [
                 "arm64"
             ],
-            "libc": [
-                "musl"
-            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -2644,9 +2599,6 @@
             "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
             "cpu": [
                 "x64"
-            ],
-            "libc": [
-                "musl"
             ],
             "license": "Apache-2.0",
             "optional": true,
@@ -3105,9 +3057,6 @@
             "cpu": [
                 "arm64"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3123,9 +3072,6 @@
             "integrity": "sha512-S4J2v+8tT3NIO9u2q+S0G5KdvNDjXfAv06OhfOzNDaBn5rw84DGXWndOEB7d5/x852A20sW1M56vhC/tRVbccQ==",
             "cpu": [
                 "arm64"
-            ],
-            "libc": [
-                "musl"
             ],
             "license": "MIT",
             "optional": true,
@@ -3143,9 +3089,6 @@
             "cpu": [
                 "x64"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3161,9 +3104,6 @@
             "integrity": "sha512-oicJwRlyOoZXVlxmIMaTq7f8pN9QNbdes0q2FXfRsPhfCi8n8JmOZJm5oo1pwDaFbnnD421rVU409M3evFbIqg==",
             "cpu": [
                 "x64"
-            ],
-            "libc": [
-                "musl"
             ],
             "license": "MIT",
             "optional": true,
@@ -6020,9 +5960,6 @@
             "cpu": [
                 "arm64"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -6038,9 +5975,6 @@
             "integrity": "sha512-V6/wZztnBqlx5hJQqNWwFdxIKN0m38p8Jas+VoSfgH54HSj9tKTt1dZvG6JRHcjh6D7TvrJPWFGaY9UBVOaWPw==",
             "cpu": [
                 "arm64"
-            ],
-            "libc": [
-                "musl"
             ],
             "license": "MIT",
             "optional": true,
@@ -6058,9 +5992,6 @@
             "cpu": [
                 "ppc64"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -6076,9 +6007,6 @@
             "integrity": "sha512-nWwpvUSPkoFmZo0kQazZYOrT7J5DGOJ/+QHHzjvNlooDZED8oH82Yg67HvehPPLAg5fUff7TfWFHQS8IV1n3og==",
             "cpu": [
                 "s390x"
-            ],
-            "libc": [
-                "glibc"
             ],
             "license": "MIT",
             "optional": true,
@@ -6096,9 +6024,6 @@
             "cpu": [
                 "x64"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -6114,9 +6039,6 @@
             "integrity": "sha512-Jpw/0iwoKWx3LJ2rc1yjFrj+T7iHZn2JDg1Yny1ma0luviFS4mhAIcd1LFNxK3EYu3DHWCps0ydXQ5i/rrJ2ig==",
             "cpu": [
                 "x64"
-            ],
-            "libc": [
-                "musl"
             ],
             "license": "MIT",
             "optional": true,
@@ -6406,9 +6328,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -6426,9 +6345,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -6446,9 +6362,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -6466,9 +6379,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -7380,9 +7290,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -7397,9 +7304,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -7414,9 +7318,6 @@
                 "ppc64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -7431,9 +7332,6 @@
                 "riscv64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -7448,9 +7346,6 @@
                 "riscv64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -7465,9 +7360,6 @@
                 "s390x"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -7482,9 +7374,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -7499,9 +7388,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -12743,9 +12629,6 @@
             "cpu": [
                 "arm64"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -12765,9 +12648,6 @@
             "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
             "cpu": [
                 "arm64"
-            ],
-            "libc": [
-                "musl"
             ],
             "license": "MPL-2.0",
             "optional": true,
@@ -12789,9 +12669,6 @@
             "cpu": [
                 "x64"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -12811,9 +12688,6 @@
             "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
             "cpu": [
                 "x64"
-            ],
-            "libc": [
-                "musl"
             ],
             "license": "MPL-2.0",
             "optional": true,

--- a/test/fixtures/payroll-fixtures.ts
+++ b/test/fixtures/payroll-fixtures.ts
@@ -21,11 +21,15 @@ export function makeAdvance(overrides?: Partial<{
     id: string;
     advanceRequestId: string;
     status: "Installment Loan" | "Installment Paid";
+    amount: number;
+    repaymentDate: string | null;
 }>) {
     return {
         id: "adv-1",
         advanceRequestId: "req-1",
         status: "Installment Loan" as const,
+        amount: 100,
+        repaymentDate: "2025-03-15",
         ...overrides,
     };
 }

--- a/test/integration/worker-overview-page.test.ts
+++ b/test/integration/worker-overview-page.test.ts
@@ -5,10 +5,20 @@ const mocks = vi.hoisted(() => ({
     db: {
         select: vi.fn(),
     },
+    requirePermission: vi.fn(),
+    checkPermission: vi.fn(),
 }));
 
 vi.mock("@/lib/db", () => ({
     db: mocks.db,
+}));
+
+vi.mock("@/utils/permissions/require-permission", () => ({
+    requirePermission: (...args: unknown[]) => mocks.requirePermission(...args),
+}));
+
+vi.mock("@/utils/permissions/permissions", () => ({
+    checkPermission: (...args: unknown[]) => mocks.checkPermission(...args),
 }));
 
 import WorkerOverviewPage from "@/app/dashboard/worker/page";
@@ -16,6 +26,8 @@ import WorkerOverviewPage from "@/app/dashboard/worker/page";
 describe("WorkerOverviewPage", () => {
     beforeEach(() => {
         vi.clearAllMocks();
+        mocks.requirePermission.mockResolvedValue({ userId: "user-1" });
+        mocks.checkPermission.mockResolvedValue(false);
     });
 
     it("renders totals and active/inactive breakdown", async () => {

--- a/test/unit/payroll-actions.test.ts
+++ b/test/unit/payroll-actions.test.ts
@@ -23,7 +23,7 @@ vi.mock("@/lib/db", () => ({
     db: mocks.db,
 }));
 
-import { settlePayroll } from "@/app/dashboard/payroll/actions";
+import { settlePayroll, revertPayroll, getRevertPreview } from "@/app/dashboard/payroll/actions";
 
 describe("settlePayroll", () => {
     beforeEach(() => {
@@ -117,5 +117,299 @@ describe("settlePayroll", () => {
         expect(mocks.revalidatePath).toHaveBeenCalledWith("/dashboard/timesheet");
         expect(mocks.revalidatePath).toHaveBeenCalledWith("/dashboard/timesheet/all");
         expect(txUpdate).toHaveBeenCalled();
+    });
+});
+
+describe("revertPayroll", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mocks.requirePermission.mockResolvedValue(undefined);
+    });
+
+    it("returns error when payroll is missing", async () => {
+        mocks.db.select.mockReturnValueOnce({
+            from: vi.fn().mockReturnValue({
+                where: vi.fn().mockReturnValue({
+                    limit: vi.fn().mockResolvedValue([]),
+                }),
+            }),
+        });
+
+        const result = await revertPayroll("missing");
+
+        expect(result).toEqual({ error: "Payroll not found" });
+    });
+
+    it("returns error when payroll is not Settled", async () => {
+        mocks.db.select.mockReturnValueOnce({
+            from: vi.fn().mockReturnValue({
+                where: vi.fn().mockReturnValue({
+                    limit: vi.fn().mockResolvedValue([makePayroll({ status: "Draft" })]),
+                }),
+            }),
+        });
+
+        const result = await revertPayroll("payroll-1");
+        expect(result).toEqual({ error: "Only Settled payrolls can be reverted" });
+    });
+
+    it("reverts payroll and revalidates routes", async () => {
+        mocks.db.select.mockReturnValueOnce({
+            from: vi.fn().mockReturnValue({
+                where: vi.fn().mockReturnValue({
+                    limit: vi.fn().mockResolvedValue([makePayroll({ status: "Settled" })]),
+                }),
+            }),
+        });
+
+        const txUpdateWhere = vi.fn().mockResolvedValue(undefined);
+        const txUpdateSet = vi.fn().mockReturnValue({ where: txUpdateWhere });
+        const txUpdate = vi.fn().mockReturnValue({ set: txUpdateSet });
+
+        const advancesInPeriod = [
+            makeAdvance({ id: "adv-1", advanceRequestId: "req-1", status: "Installment Paid" }),
+            makeAdvance({ id: "adv-2", advanceRequestId: "req-2", status: "Installment Loan" }),
+        ];
+        const requestAdvances = [
+            { advanceRequestId: "req-1", status: "Installment Loan" as const },
+            { advanceRequestId: "req-2", status: "Installment Loan" as const },
+        ];
+
+        const txSelect = vi
+            .fn()
+            .mockReturnValueOnce({
+                from: vi.fn().mockReturnValue({
+                    innerJoin: vi.fn().mockReturnValue({
+                        where: vi.fn().mockResolvedValue(advancesInPeriod),
+                    }),
+                }),
+            })
+            .mockReturnValueOnce({
+                from: vi.fn().mockReturnValue({
+                    where: vi.fn().mockResolvedValue(requestAdvances),
+                }),
+            });
+
+        mocks.db.transaction.mockImplementationOnce(async (cb: (tx: unknown) => Promise<void>) =>
+            cb({
+                update: txUpdate,
+                select: txSelect,
+            }),
+        );
+
+        const result = await revertPayroll("payroll-1");
+
+        expect(result).toEqual({ success: true });
+        expect(mocks.requirePermission).toHaveBeenCalledWith("Payroll", "update");
+        expect(mocks.db.transaction).toHaveBeenCalledTimes(1);
+
+        expect(mocks.revalidatePath).toHaveBeenCalledWith("/dashboard/payroll/payroll-1/breakdown");
+        expect(mocks.revalidatePath).toHaveBeenCalledWith("/dashboard/payroll/payroll-1/summary");
+        expect(mocks.revalidatePath).toHaveBeenCalledWith("/dashboard/payroll");
+        expect(mocks.revalidatePath).toHaveBeenCalledWith("/dashboard/payroll/all");
+        expect(mocks.revalidatePath).toHaveBeenCalledWith("/dashboard/advance");
+        expect(mocks.revalidatePath).toHaveBeenCalledWith("/dashboard/advance/all");
+        expect(mocks.revalidatePath).toHaveBeenCalledWith("/dashboard/timesheet");
+        expect(mocks.revalidatePath).toHaveBeenCalledWith("/dashboard/timesheet/all");
+        expect(txUpdate).toHaveBeenCalled();
+    });
+});
+
+describe("getRevertPreview", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mocks.requirePermission.mockResolvedValue(undefined);
+    });
+
+    it("returns error when payroll not found", async () => {
+        mocks.db.select.mockReturnValueOnce({
+            from: vi.fn().mockReturnValue({
+                where: vi.fn().mockReturnValue({
+                    limit: vi.fn().mockResolvedValue([]),
+                }),
+            }),
+        });
+
+        const result = await getRevertPreview("missing");
+        expect(result).toEqual({ error: "Payroll not found" });
+    });
+
+    it("returns error when payroll is not Settled", async () => {
+        mocks.db.select.mockReturnValueOnce({
+            from: vi.fn().mockReturnValue({
+                where: vi.fn().mockReturnValue({
+                    limit: vi.fn().mockResolvedValue([makePayroll({ status: "Draft" })]),
+                }),
+            }),
+        });
+
+        const result = await getRevertPreview("payroll-1");
+        expect(result).toEqual({
+            error: "Only Settled payrolls can be previewed for revert",
+        });
+    });
+
+    it("returns preview with all 4 row types when all entities are affected", async () => {
+        mocks.db.select.mockReturnValueOnce({
+            from: vi.fn().mockReturnValue({
+                where: vi.fn().mockReturnValue({
+                    limit: vi.fn().mockResolvedValue([makePayroll({ status: "Settled" })]),
+                }),
+            }),
+        });
+
+        mocks.db.select.mockReturnValueOnce({
+            from: vi.fn().mockReturnValue({
+                where: vi.fn().mockReturnValue({
+                    orderBy: vi.fn().mockResolvedValue([
+                        {
+                            id: "ts-1",
+                            dateIn: "2025-03-01",
+                            dateOut: "2025-03-01",
+                            timeIn: "09:00:00",
+                            timeOut: "17:00:00",
+                            hours: 8,
+                        },
+                        {
+                            id: "ts-2",
+                            dateIn: "2025-03-02",
+                            dateOut: "2025-03-02",
+                            timeIn: "08:30:00",
+                            timeOut: "16:00:00",
+                            hours: 7.5,
+                        },
+                        {
+                            id: "ts-3",
+                            dateIn: "2025-03-03",
+                            dateOut: "2025-03-04",
+                            timeIn: "10:00:00",
+                            timeOut: "19:00:00",
+                            hours: 9,
+                        },
+                    ]),
+                }),
+            }),
+        });
+
+        mocks.db.select.mockReturnValueOnce({
+            from: vi.fn().mockReturnValue({
+                innerJoin: vi.fn().mockReturnValue({
+                    where: vi.fn().mockResolvedValue([
+                        makeAdvance({
+                            id: "adv-1",
+                            advanceRequestId: "req-1",
+                            status: "Installment Paid",
+                            amount: 40,
+                            repaymentDate: "2025-03-10",
+                        }),
+                        makeAdvance({
+                            id: "adv-2",
+                            advanceRequestId: "req-1",
+                            status: "Installment Paid",
+                            amount: 60,
+                            repaymentDate: "2025-03-12",
+                        }),
+                    ]),
+                }),
+            }),
+        });
+
+        mocks.db.select.mockReturnValueOnce({
+            from: vi.fn().mockReturnValue({
+                where: vi.fn().mockResolvedValue([
+                    { advanceRequestId: "req-1", status: "Installment Paid" as const },
+                    { advanceRequestId: "req-1", status: "Installment Paid" as const },
+                ]),
+            }),
+        });
+
+        const result = await getRevertPreview("payroll-1");
+        expect(result).toEqual({
+            data: [
+                { name: "Payroll", currentStatus: "Settled", futureStatus: "Draft" },
+                {
+                    name: "Timesheets (3)",
+                    currentStatus: "Timesheet Paid",
+                    futureStatus: "Timesheet Unpaid",
+                    timesheetLines: [
+                        {
+                            id: "ts-1",
+                            dateIn: "2025-03-01",
+                            dateOut: "2025-03-01",
+                            timeIn: "09:00:00",
+                            timeOut: "17:00:00",
+                            hours: 8,
+                        },
+                        {
+                            id: "ts-2",
+                            dateIn: "2025-03-02",
+                            dateOut: "2025-03-02",
+                            timeIn: "08:30:00",
+                            timeOut: "16:00:00",
+                            hours: 7.5,
+                        },
+                        {
+                            id: "ts-3",
+                            dateIn: "2025-03-03",
+                            dateOut: "2025-03-04",
+                            timeIn: "10:00:00",
+                            timeOut: "19:00:00",
+                            hours: 9,
+                        },
+                    ],
+                },
+                {
+                    name: "Advance (2)",
+                    currentStatus: "Installment Paid",
+                    futureStatus: "Installment Loan",
+                    advanceInstallmentLines: [
+                        {
+                            id: "adv-1",
+                            amount: 40,
+                            repaymentDate: "2025-03-10",
+                        },
+                        {
+                            id: "adv-2",
+                            amount: 60,
+                            repaymentDate: "2025-03-12",
+                        },
+                    ],
+                },
+                { name: "Advance Requests (1)", currentStatus: "Advance Paid", futureStatus: "Advance Loan" },
+            ],
+        });
+    });
+
+    it("omits rows with 0 affected records", async () => {
+        mocks.db.select.mockReturnValueOnce({
+            from: vi.fn().mockReturnValue({
+                where: vi.fn().mockReturnValue({
+                    limit: vi.fn().mockResolvedValue([makePayroll({ status: "Settled" })]),
+                }),
+            }),
+        });
+
+        mocks.db.select.mockReturnValueOnce({
+            from: vi.fn().mockReturnValue({
+                where: vi.fn().mockReturnValue({
+                    orderBy: vi.fn().mockResolvedValue([]),
+                }),
+            }),
+        });
+
+        mocks.db.select.mockReturnValueOnce({
+            from: vi.fn().mockReturnValue({
+                innerJoin: vi.fn().mockReturnValue({
+                    where: vi.fn().mockResolvedValue([]),
+                }),
+            }),
+        });
+
+        const result = await getRevertPreview("payroll-1");
+        expect(result).toEqual({
+            data: [
+                { name: "Payroll", currentStatus: "Settled", futureStatus: "Draft" },
+            ],
+        });
     });
 });

--- a/test/unit/payroll-step-progress.test.tsx
+++ b/test/unit/payroll-step-progress.test.tsx
@@ -7,6 +7,8 @@ import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/re
 const mocks = vi.hoisted(() => ({
     push: vi.fn(),
     settlePayroll: vi.fn(),
+    revertPayroll: vi.fn(),
+    getRevertPreview: vi.fn(),
 }));
 
 vi.mock("next/navigation", () => ({
@@ -25,9 +27,13 @@ vi.mock("@/components/ui/step-progress-panel", () => ({
 
 vi.mock("@/app/dashboard/payroll/actions", () => ({
     settlePayroll: (...args: unknown[]) => mocks.settlePayroll(...args),
+    revertPayroll: (...args: unknown[]) => mocks.revertPayroll(...args),
+    getRevertPreview: (...args: unknown[]) => mocks.getRevertPreview(...args),
 }));
 
 import { PayrollStepProgress } from "@/app/dashboard/payroll/[id]/payroll-step-progress";
+import { localDateDmy } from "@/utils/time/local-iso-date";
+import { localTimeHm } from "@/utils/time/local-time";
 
 function createDeferred<T>() {
     let resolve!: (value: T | PromiseLike<T>) => void;
@@ -46,6 +52,15 @@ describe("PayrollStepProgress", () => {
 
     beforeEach(() => {
         vi.clearAllMocks();
+        mocks.getRevertPreview.mockResolvedValue({
+            data: [
+                {
+                    name: "Payroll",
+                    currentStatus: "Settled",
+                    futureStatus: "Draft",
+                },
+            ],
+        });
     });
 
     it("prevents duplicate settle submissions on rapid confirm clicks", async () => {
@@ -114,5 +129,330 @@ describe("PayrollStepProgress", () => {
         const revert = screen.getByRole("button", { name: "Revert" });
         expect(revert).toBeTruthy();
         expect((revert as HTMLButtonElement).disabled).toBe(false);
+    });
+
+    it("opens confirmation dialog when Revert is clicked", async () => {
+        render(
+            <PayrollStepProgress
+                payrollId="payroll-1"
+                payrollStatus="Settled"
+                activeStep={3}
+            />,
+        );
+
+        fireEvent.click(screen.getByRole("button", { name: "Revert" }));
+
+        expect(await screen.findByText("Confirm revert")).toBeTruthy();
+        expect(
+            screen.getByText("The following changes will be applied:"),
+        ).toBeTruthy();
+    });
+
+    it("calls revertPayroll on confirm and navigates to breakdown", async () => {
+        mocks.revertPayroll.mockResolvedValueOnce({ success: true });
+
+        render(
+            <PayrollStepProgress
+                payrollId="payroll-1"
+                payrollStatus="Settled"
+                activeStep={3}
+            />,
+        );
+
+        fireEvent.click(screen.getByRole("button", { name: "Revert" }));
+        fireEvent.click(
+            await screen.findByRole("button", { name: "Yes, revert" }),
+        );
+
+        await waitFor(() => {
+            expect(mocks.revertPayroll).toHaveBeenCalledWith("payroll-1");
+        });
+
+        await waitFor(() => {
+            expect(mocks.push).toHaveBeenCalledWith(
+                "/dashboard/payroll/payroll-1/breakdown",
+            );
+        });
+    });
+
+    it("shows error in dialog when revert fails", async () => {
+        mocks.revertPayroll.mockResolvedValueOnce({
+            error: "Only Settled payrolls can be reverted",
+        });
+
+        render(
+            <PayrollStepProgress
+                payrollId="payroll-1"
+                payrollStatus="Settled"
+                activeStep={3}
+            />,
+        );
+
+        fireEvent.click(screen.getByRole("button", { name: "Revert" }));
+        fireEvent.click(
+            await screen.findByRole("button", { name: "Yes, revert" }),
+        );
+
+        expect(
+            await screen.findByText("Only Settled payrolls can be reverted"),
+        ).toBeTruthy();
+        expect(mocks.push).not.toHaveBeenCalled();
+    });
+
+    it("prevents duplicate revert submissions on rapid confirm clicks", async () => {
+        const revertDeferred = createDeferred<{ success: true }>();
+        mocks.revertPayroll.mockImplementationOnce(() => revertDeferred.promise);
+
+        render(
+            <PayrollStepProgress
+                payrollId="payroll-1"
+                payrollStatus="Settled"
+                activeStep={3}
+            />,
+        );
+
+        fireEvent.click(screen.getByRole("button", { name: "Revert" }));
+        const confirmButton = await screen.findByRole("button", {
+            name: "Yes, revert",
+        });
+        fireEvent.click(confirmButton);
+        fireEvent.click(confirmButton);
+
+        expect(mocks.revertPayroll).toHaveBeenCalledTimes(1);
+
+        revertDeferred.resolve({ success: true });
+
+        await waitFor(() => {
+            expect(mocks.push).toHaveBeenCalledWith(
+                "/dashboard/payroll/payroll-1/breakdown",
+            );
+        });
+        expect(mocks.push).toHaveBeenCalledTimes(1);
+    });
+
+    it("shows loading state when revert dialog opens", async () => {
+        const previewDeferred = createDeferred<{
+            data: { name: string; currentStatus: string; futureStatus: string }[];
+        }>();
+        mocks.getRevertPreview.mockImplementationOnce(
+            () => previewDeferred.promise,
+        );
+
+        render(
+            <PayrollStepProgress
+                payrollId="payroll-1"
+                payrollStatus="Settled"
+                activeStep={3}
+            />,
+        );
+
+        fireEvent.click(screen.getByRole("button", { name: "Revert" }));
+
+        expect(await screen.findByText("Loading preview...")).toBeTruthy();
+
+        previewDeferred.resolve({
+            data: [
+                {
+                    name: "Payroll",
+                    currentStatus: "Settled",
+                    futureStatus: "Draft",
+                },
+            ],
+        });
+    });
+
+    it("renders preview table with Name / Current Status / Future Status columns after data loads", async () => {
+        mocks.getRevertPreview.mockResolvedValueOnce({
+            data: [
+                {
+                    name: "Payroll",
+                    currentStatus: "Settled",
+                    futureStatus: "Draft",
+                },
+                {
+                    name: "Timesheets (3)",
+                    currentStatus: "Timesheet Paid",
+                    futureStatus: "Timesheet Unpaid",
+                },
+            ],
+        });
+
+        render(
+            <PayrollStepProgress
+                payrollId="payroll-1"
+                payrollStatus="Settled"
+                activeStep={3}
+            />,
+        );
+
+        fireEvent.click(screen.getByRole("button", { name: "Revert" }));
+
+        expect(await screen.findByRole("table")).toBeTruthy();
+        expect(screen.getByText("Name")).toBeTruthy();
+        expect(screen.getByText("Current Status")).toBeTruthy();
+        expect(screen.getByText("Future Status")).toBeTruthy();
+        expect(screen.getByText("Payroll")).toBeTruthy();
+        expect(screen.getByText("Settled")).toBeTruthy();
+        expect(screen.getByText("Draft")).toBeTruthy();
+        expect(screen.getByText("Timesheets (3)")).toBeTruthy();
+        expect(screen.getByText("Timesheet Paid")).toBeTruthy();
+        expect(screen.getByText("Timesheet Unpaid")).toBeTruthy();
+    });
+
+    it("expands Timesheets row to show timesheet detail sub-table from preview", async () => {
+        mocks.getRevertPreview.mockResolvedValueOnce({
+            data: [
+                {
+                    name: "Payroll",
+                    currentStatus: "Settled",
+                    futureStatus: "Draft",
+                },
+                {
+                    name: "Timesheets (1)",
+                    currentStatus: "Timesheet Paid",
+                    futureStatus: "Timesheet Unpaid",
+                    timesheetLines: [
+                        {
+                            id: "ts-1",
+                            dateIn: "2025-03-01",
+                            dateOut: "2025-03-02",
+                            timeIn: "09:15:00",
+                            timeOut: "17:30:00",
+                            hours: 8.25,
+                        },
+                    ],
+                },
+            ],
+        });
+
+        render(
+            <PayrollStepProgress
+                payrollId="payroll-1"
+                payrollStatus="Settled"
+                activeStep={3}
+            />,
+        );
+
+        fireEvent.click(screen.getByRole("button", { name: "Revert" }));
+        expect(await screen.findByRole("table")).toBeTruthy();
+
+        expect(screen.queryByRole("columnheader", { name: "Date in" })).toBeNull();
+
+        fireEvent.click(
+            screen.getByRole("button", { name: /Timesheets \(1\)/ }),
+        );
+
+        expect(
+            await screen.findByRole("columnheader", { name: "Date in" }),
+        ).toBeTruthy();
+        expect(screen.getByText(localDateDmy("2025-03-01"))).toBeTruthy();
+        expect(screen.getByText(localDateDmy("2025-03-02"))).toBeTruthy();
+        expect(screen.getByText(localTimeHm("09:15:00"))).toBeTruthy();
+        expect(screen.getByText(localTimeHm("17:30:00"))).toBeTruthy();
+        expect(screen.getByText("8.25")).toBeTruthy();
+    });
+
+    it("expands Advance row to show repayment date and amount columns from preview", async () => {
+        mocks.getRevertPreview.mockResolvedValueOnce({
+            data: [
+                {
+                    name: "Payroll",
+                    currentStatus: "Settled",
+                    futureStatus: "Draft",
+                },
+                {
+                    name: "Advance (1)",
+                    currentStatus: "Installment Paid",
+                    futureStatus: "Installment Loan",
+                    advanceInstallmentLines: [
+                        {
+                            id: "adv-1",
+                            amount: 40,
+                            repaymentDate: "2025-03-10",
+                        },
+                    ],
+                },
+            ],
+        });
+
+        render(
+            <PayrollStepProgress
+                payrollId="payroll-1"
+                payrollStatus="Settled"
+                activeStep={3}
+            />,
+        );
+
+        fireEvent.click(screen.getByRole("button", { name: "Revert" }));
+        expect(await screen.findByRole("table")).toBeTruthy();
+
+        expect(
+            screen.queryByRole("columnheader", { name: "Repayment date" }),
+        ).toBeNull();
+
+        fireEvent.click(screen.getByRole("button", { name: /Advance \(1\)/ }));
+
+        expect(
+            await screen.findByRole("columnheader", { name: "Repayment date" }),
+        ).toBeTruthy();
+        expect(
+            screen.getByRole("columnheader", { name: "Amount" }),
+        ).toBeTruthy();
+        expect(screen.getByText(localDateDmy("2025-03-10"))).toBeTruthy();
+        expect(screen.getByText("$40")).toBeTruthy();
+    });
+
+    it("shows error message if preview fetch fails", async () => {
+        mocks.getRevertPreview.mockResolvedValueOnce({
+            error: "Payroll not found",
+        });
+
+        render(
+            <PayrollStepProgress
+                payrollId="payroll-1"
+                payrollStatus="Settled"
+                activeStep={3}
+            />,
+        );
+
+        fireEvent.click(screen.getByRole("button", { name: "Revert" }));
+
+        expect(await screen.findByText("Payroll not found")).toBeTruthy();
+    });
+
+    it("revert confirm button still works after preview loads", async () => {
+        mocks.getRevertPreview.mockResolvedValueOnce({
+            data: [
+                {
+                    name: "Payroll",
+                    currentStatus: "Settled",
+                    futureStatus: "Draft",
+                },
+            ],
+        });
+        mocks.revertPayroll.mockResolvedValueOnce({ success: true });
+
+        render(
+            <PayrollStepProgress
+                payrollId="payroll-1"
+                payrollStatus="Settled"
+                activeStep={3}
+            />,
+        );
+
+        fireEvent.click(screen.getByRole("button", { name: "Revert" }));
+
+        expect(await screen.findByRole("table")).toBeTruthy();
+
+        fireEvent.click(screen.getByRole("button", { name: "Yes, revert" }));
+
+        await waitFor(() => {
+            expect(mocks.revertPayroll).toHaveBeenCalledWith("payroll-1");
+        });
+        await waitFor(() => {
+            expect(mocks.push).toHaveBeenCalledWith(
+                "/dashboard/payroll/payroll-1/breakdown",
+            );
+        });
     });
 });

--- a/test/unit/worker-mass-edit-working-hours-result-table.test.tsx
+++ b/test/unit/worker-mass-edit-working-hours-result-table.test.tsx
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { renderToStaticMarkup } from "react-dom/server";
 
-import { MassEditWorkingHoursResultTable } from "@/app/dashboard/worker/mass-edit-working-hours-result-table";
+import { MassEditWorkingHoursResultTable } from "@/app/dashboard/worker/mass-edit/mass-edit-working-hours-result-table";
 
 describe("MassEditWorkingHoursResultTable", () => {
     it("renders headers, formatted hours, and emoji status", () => {


### PR DESCRIPTION
## Summary

- Extend `getRevertPreview` with structured `timesheetLines` (date in/out, time in/out, hours) and `advanceInstallmentLines` (repayment date, amount). Rename paid-installment aggregate row to **Advance (n)**.
- Revert confirmation dialog: nested detail tables, expandable rows without invalid table markup, wider (`max-w-6xl`) and taller viewport use.
- Unit test and fixture updates; includes other staged test/lockfile changes and `CLAUDE.md`.

## Testing

- `npx vitest run test/unit/payroll-actions.test.ts test/unit/payroll-step-progress.test.tsx`

Made with [Cursor](https://cursor.com)