### PR TITLE
feat: payroll download/settle routes, worker mass-edit panels, data-t…

### DIFF
--- a/app/dashboard/payroll/all/payroll-all-table-loader.tsx
+++ b/app/dashboard/payroll/all/payroll-all-table-loader.tsx
@@ -9,7 +9,10 @@ import { DataTable } from "@/components/data-table/data-table";
 import { Button } from "@/components/ui/button";
 import { Plus } from "lucide-react";
 
-import { columns, type PayrollWithWorker } from "./columns";
+import {
+    columns,
+    type PayrollWithWorker,
+} from "@/app/dashboard/payroll/columns";
 
 export async function PayrollAllTableLoader() {
     const rows = await db

--- a/app/dashboard/payroll/columns.tsx
+++ b/app/dashboard/payroll/columns.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { ColumnDef } from "@tanstack/react-table";
-import type { SelectPayroll } from "@/db/tables/payroll/payrollTable";
+import type { SelectPayroll } from "@/db/tables/payrollTable";
 import Link from "next/link";
 import { DropdownMenuItem } from "@/components/ui/dropdown-menu";
 import {
@@ -21,6 +21,7 @@ import type {
     WorkerEmploymentType,
 } from "@/types/status";
 import { Eye } from "lucide-react";
+import { formatEnGbDmyNumericFromCalendar } from "@/utils/time/intl-en-gb";
 
 export type PayrollWithWorker = SelectPayroll & {
     workerName: string;
@@ -28,15 +29,6 @@ export type PayrollWithWorker = SelectPayroll & {
     employmentType: WorkerEmploymentType;
     employmentArrangement: WorkerEmploymentArrangement;
 };
-
-function formatDate(d: string | Date): string {
-    const date = d instanceof Date ? d : new Date(d + "T00:00:00");
-    return date.toLocaleDateString("en-GB", {
-        year: "numeric",
-        month: "2-digit",
-        day: "2-digit",
-    });
-}
 
 export const columns: ColumnDef<PayrollWithWorker>[] = [
     {
@@ -78,17 +70,17 @@ export const columns: ColumnDef<PayrollWithWorker>[] = [
     {
         accessorKey: "periodStart",
         header: createSortableHeader("Period Start"),
-        cell: ({ row }) => formatDate(row.original.periodStart),
+        cell: ({ row }) => formatEnGbDmyNumericFromCalendar(row.original.periodStart),
     },
     {
         accessorKey: "periodEnd",
         header: createSortableHeader("Period End"),
-        cell: ({ row }) => formatDate(row.original.periodEnd),
+        cell: ({ row }) => formatEnGbDmyNumericFromCalendar(row.original.periodEnd),
     },
     {
         accessorKey: "payrollDate",
         header: createSortableHeader("Payroll Date"),
-        cell: ({ row }) => formatDate(row.original.payrollDate),
+        cell: ({ row }) => formatEnGbDmyNumericFromCalendar(row.original.payrollDate),
     },
     createActionsColumn<PayrollWithWorker>({
         cell: (payroll) => (

--- a/app/dashboard/payroll/download-payrolls/download-payrolls-panel.tsx
+++ b/app/dashboard/payroll/download-payrolls/download-payrolls-panel.tsx
@@ -3,24 +3,16 @@
 import * as React from "react";
 import type { ColumnDef } from "@tanstack/react-table";
 import type { RowSelectionState } from "@tanstack/react-table";
-import { Download } from "lucide-react";
-import { usePathname } from "next/navigation";
 
 import { Button } from "@/components/ui/button";
-import {
-    Dialog,
-    DialogClose,
-    DialogContent,
-    DialogDescription,
-    DialogFooter,
-    DialogHeader,
-    DialogTitle,
-    DialogTrigger,
-} from "@/components/ui/dialog";
+import { Card, CardContent } from "@/components/ui/card";
 import { DataTable } from "@/components/data-table/data-table";
 import { createRowSelectionColumn } from "@/components/data-table/column-builders";
-import { columns as baseColumns, type PayrollWithWorker } from "./all/columns";
-import { fetchPayrollDownloadSelection } from "./read-api";
+import {
+    columns as baseColumns,
+    type PayrollWithWorker,
+} from "@/app/dashboard/payroll/columns";
+import { fetchPayrollDownloadSelection } from "@/app/dashboard/payroll/read-api";
 
 const selectableColumns: ColumnDef<PayrollWithWorker>[] = [
     createRowSelectionColumn<PayrollWithWorker>({
@@ -55,12 +47,10 @@ function getDownloadFilenameFromContentDisposition(
     return null;
 }
 
-export function DownloadPayrollsButton() {
-    const pathname = usePathname();
-    const [open, setOpen] = React.useState(false);
+export function DownloadPayrollsPanel() {
     const [downloading, setDownloading] = React.useState(false);
     const [error, setError] = React.useState<string | null>(null);
-    const [loading, setLoading] = React.useState(false);
+    const [loading, setLoading] = React.useState(true);
     const [payrolls, setPayrolls] = React.useState<PayrollWithWorker[]>([]);
     const [rowSelection, setRowSelection] = React.useState<RowSelectionState>(
         {},
@@ -70,36 +60,9 @@ export function DownloadPayrollsButton() {
         (k) => rowSelection[k],
     ).length;
 
-    const resetDownloadDialogUi = React.useCallback(() => {
-        setError(null);
-        setLoading(false);
-    }, []);
-
-    const wasDownloadDialogOpen = React.useRef(false);
-    const downloadDialogOpenedAtPath = React.useRef<string | null>(null);
-
-    React.useEffect(() => {
-        if (open && !wasDownloadDialogOpen.current) {
-            downloadDialogOpenedAtPath.current = pathname;
-        }
-        if (!open) {
-            downloadDialogOpenedAtPath.current = null;
-        }
-        wasDownloadDialogOpen.current = open;
-    }, [open, pathname]);
-
-    React.useEffect(() => {
-        if (!open || downloadDialogOpenedAtPath.current === null) return;
-        if (pathname !== downloadDialogOpenedAtPath.current) {
-            setOpen(false);
-            resetDownloadDialogUi();
-        }
-    }, [pathname, open, resetDownloadDialogUi]);
-
     React.useEffect(() => {
         let cancelled = false;
         async function load() {
-            if (!open) return;
             setLoading(true);
             setError(null);
             setRowSelection({});
@@ -120,7 +83,7 @@ export function DownloadPayrollsButton() {
         return () => {
             cancelled = true;
         };
-    }, [open]);
+    }, []);
 
     async function handleDownload() {
         const selectedIds = Object.keys(rowSelection).filter(
@@ -152,8 +115,6 @@ export function DownloadPayrollsButton() {
             a.click();
             a.remove();
             URL.revokeObjectURL(url);
-            setOpen(false);
-            resetDownloadDialogUi();
         } catch (e) {
             console.error(e);
             setError("Failed to download payroll PDFs");
@@ -163,29 +124,13 @@ export function DownloadPayrollsButton() {
     }
 
     return (
-        <Dialog
-            open={open}
-            onOpenChange={(nextOpen) => {
-                setOpen(nextOpen);
-                if (!nextOpen) {
-                    resetDownloadDialogUi();
-                }
-            }}>
-            <DialogTrigger asChild>
-                <Button type="button" variant="outline" disabled={downloading}>
-                    <Download className="mr-2 h-4 w-4" />
-                    Download payrolls
-                </Button>
-            </DialogTrigger>
-            <DialogContent className="flex max-h-[90vh] w-[calc(100vw-2rem)] max-w-[calc(100vw-2rem)] flex-col sm:max-w-[calc(100vw-2rem)] [&_button]:cursor-pointer">
-                <DialogHeader>
-                    <DialogTitle>Download payrolls</DialogTitle>
-                    <DialogDescription>
-                        Select the payrolls you want to download as a ZIP of PDF
-                        summaries.
-                    </DialogDescription>
-                </DialogHeader>
-                <div className="min-h-0 min-w-0 flex-1 overflow-y-auto overflow-x-auto">
+        <Card>
+            <CardContent className="space-y-4 pt-6">
+                <p className="text-muted-foreground text-sm">
+                    Select the payrolls you want to download as a ZIP of PDF
+                    summaries.
+                </p>
+                <div className="max-h-[min(75vh,64rem)] min-h-0 overflow-auto">
                     <DataTable
                         columns={selectableColumns}
                         data={payrolls}
@@ -203,27 +148,17 @@ export function DownloadPayrollsButton() {
                 {error ? (
                     <p className="text-sm text-destructive">{error}</p>
                 ) : null}
-                <DialogFooter>
-                    <DialogClose asChild>
-                        <Button
-                            type="button"
-                            variant="outline"
-                            disabled={downloading}>
-                            Cancel
-                        </Button>
-                    </DialogClose>
+                <div className="flex flex-wrap justify-end gap-2">
                     <Button
                         type="button"
-                        disabled={
-                            downloading || loading || selectedCount === 0
-                        }
+                        disabled={downloading || loading || selectedCount === 0}
                         onClick={handleDownload}>
                         {downloading
                             ? "Preparing ZIP..."
                             : `Download selected (${selectedCount})`}
                     </Button>
-                </DialogFooter>
-            </DialogContent>
-        </Dialog>
+                </div>
+            </CardContent>
+        </Card>
     );
 }

--- a/app/dashboard/payroll/download-payrolls/page.tsx
+++ b/app/dashboard/payroll/download-payrolls/page.tsx
@@ -1,0 +1,14 @@
+import { FormPageLayout } from "@/components/form-page-layout";
+
+import { DownloadPayrollsPanel } from "@/app/dashboard/payroll/download-payrolls/download-payrolls-panel";
+
+export default function DownloadPayrollsPage() {
+    return (
+        <FormPageLayout
+            title="Download payrolls"
+            subtitle="Choose payroll runs to bundle as a ZIP of PDF summaries."
+            maxWidthClassName="max-w-screen-2xl">
+            <DownloadPayrollsPanel />
+        </FormPageLayout>
+    );
+}

--- a/app/dashboard/payroll/page.tsx
+++ b/app/dashboard/payroll/page.tsx
@@ -2,7 +2,7 @@ import { Suspense } from "react";
 
 import { DashboardHubOverviewSkeleton } from "@/components/dashboard/dashboard-page-skeleton";
 
-import { PayrollOverviewLoader } from "./payroll-overview-loader";
+import { PayrollOverviewLoader } from "@/app/dashboard/payroll/payroll-overview-loader";
 
 export default function PayrollOverviewPage() {
     return (

--- a/app/dashboard/payroll/payroll-overview-loader.tsx
+++ b/app/dashboard/payroll/payroll-overview-loader.tsx
@@ -12,9 +12,7 @@ import {
     CardTitle,
 } from "@/components/ui/card";
 import { SimpleDonutChart } from "@/components/dashboard/simple-donut-chart";
-import { ArrowRight, Plus, Wallet } from "lucide-react";
-import { SettleAllDraftPayrollsButton } from "./settle-all-drafts-button";
-import { DownloadPayrollsButton } from "./download-payrolls-button";
+import { ArrowRight, Download, Plus, Wallet } from "lucide-react";
 
 export async function PayrollOverviewLoader() {
     const [[{ total }], [{ draftCount }]] = await Promise.all([
@@ -52,8 +50,18 @@ export async function PayrollOverviewLoader() {
                         <ArrowRight className="ml-2 h-4 w-4" />
                     </Link>
                 </Button>
-                <SettleAllDraftPayrollsButton />
-                <DownloadPayrollsButton />
+                <Button variant="destructive" asChild>
+                    <Link href="/dashboard/payroll/settle-drafts">
+                        Settle drafts
+                        <ArrowRight className="ml-2 h-4 w-4" />
+                    </Link>
+                </Button>
+                <Button variant="outline" asChild>
+                    <Link href="/dashboard/payroll/download-payrolls">
+                        <Download className="mr-2 h-4 w-4" />
+                        Download payrolls
+                    </Link>
+                </Button>
                 <Button variant="outline" asChild>
                     <Link href="/dashboard/payroll/new">
                         <Plus className="mr-2 h-4 w-4" />

--- a/app/dashboard/payroll/selection-dialogs.test.tsx
+++ b/app/dashboard/payroll/selection-dialogs.test.tsx
@@ -2,7 +2,7 @@
 
 import React from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { cleanup, render, screen } from "@testing-library/react";
 
 const mocks = vi.hoisted(() => ({
     push: vi.fn(),
@@ -17,7 +17,6 @@ vi.mock("next/navigation", () => ({
         push: mocks.push,
         refresh: mocks.refresh,
     }),
-    usePathname: () => "/dashboard/payroll",
 }));
 
 vi.mock("@/app/dashboard/payroll/read-api", () => ({
@@ -52,8 +51,8 @@ vi.mock("@/components/data-table/data-table", () => ({
     ),
 }));
 
-import { SettleAllDraftPayrollsButton } from "@/app/dashboard/payroll/settle-all-drafts-button";
-import { DownloadPayrollsButton } from "@/app/dashboard/payroll/download-payrolls-button";
+import { SettleDraftPayrollsPanel } from "@/app/dashboard/payroll/settle-draft-payrolls-panel";
+import { DownloadPayrollsPanel } from "@/app/dashboard/payroll/download-payrolls-panel";
 
 function createDeferred<T>() {
     let resolve!: (value: T | PromiseLike<T>) => void;
@@ -80,7 +79,7 @@ const payrollRow = {
     employmentArrangement: "Local Worker" as const,
 };
 
-describe("Payroll selection dialogs", () => {
+describe("Payroll selection panels", () => {
     afterEach(() => {
         cleanup();
     });
@@ -91,18 +90,16 @@ describe("Payroll selection dialogs", () => {
     });
 
     it("lazy-loads settlement candidates and preserves the loading state", async () => {
-        const deferred = createDeferred<typeof payrollRow[]>();
+        const deferred = createDeferred<(typeof payrollRow)[]>();
         mocks.fetchSettlementCandidates.mockImplementationOnce(
             () => deferred.promise,
         );
 
-        render(<SettleAllDraftPayrollsButton />);
+        render(<SettleDraftPayrollsPanel />);
 
-        fireEvent.click(
-            screen.getByRole("button", { name: "Settle all Draft payrolls" }),
-        );
-
-        expect(await screen.findByTestId("mock-datatable-loading")).toBeTruthy();
+        expect(
+            await screen.findByTestId("mock-datatable-loading"),
+        ).toBeTruthy();
 
         deferred.resolve([payrollRow]);
 
@@ -113,18 +110,16 @@ describe("Payroll selection dialogs", () => {
     });
 
     it("lazy-loads download selection rows and preserves the loading state", async () => {
-        const deferred = createDeferred<typeof payrollRow[]>();
+        const deferred = createDeferred<(typeof payrollRow)[]>();
         mocks.fetchPayrollDownloadSelection.mockImplementationOnce(
             () => deferred.promise,
         );
 
-        render(<DownloadPayrollsButton />);
+        render(<DownloadPayrollsPanel />);
 
-        fireEvent.click(
-            screen.getByRole("button", { name: "Download payrolls" }),
-        );
-
-        expect(await screen.findByTestId("mock-datatable-loading")).toBeTruthy();
+        expect(
+            await screen.findByTestId("mock-datatable-loading"),
+        ).toBeTruthy();
 
         deferred.resolve([payrollRow]);
 

--- a/app/dashboard/payroll/settle-drafts/page.tsx
+++ b/app/dashboard/payroll/settle-drafts/page.tsx
@@ -1,0 +1,14 @@
+import { FormPageLayout } from "@/components/form-page-layout";
+
+import { SettleDraftPayrollsPanel } from "@/app/dashboard/payroll/settle-drafts/settle-draft-payrolls-panel";
+
+export default function SettleDraftPayrollsPage() {
+    return (
+        <FormPageLayout
+            title="Settle draft payrolls"
+            subtitle="Select Draft payroll runs to settle. After settlement, PDFs can download as a ZIP."
+            maxWidthClassName="max-w-screen-2xl">
+            <SettleDraftPayrollsPanel />
+        </FormPageLayout>
+    );
+}

--- a/app/dashboard/payroll/settle-drafts/settle-draft-payrolls-panel.tsx
+++ b/app/dashboard/payroll/settle-drafts/settle-draft-payrolls-panel.tsx
@@ -3,26 +3,24 @@
 import * as React from "react";
 import type { ColumnDef } from "@tanstack/react-table";
 import type { RowSelectionState } from "@tanstack/react-table";
-import { usePathname, useRouter } from "next/navigation";
+import { useRouter } from "next/navigation";
 
 import { Button } from "@/components/ui/button";
 import {
-    Dialog,
-    DialogClose,
-    DialogContent,
-    DialogDescription,
-    DialogFooter,
-    DialogHeader,
-    DialogTitle,
-    DialogTrigger,
-} from "@/components/ui/dialog";
+    Card,
+    CardContent,
+    CardDescription,
+    CardHeader,
+    CardTitle,
+} from "@/components/ui/card";
 import { createRowSelectionColumn } from "@/components/data-table/column-builders";
 import { DataTable } from "@/components/data-table/data-table";
+import { settleDraftPayrolls } from "@/app/dashboard/payroll/command-api";
+import { fetchSettlementCandidates } from "@/app/dashboard/payroll/read-api";
 import {
-    settleDraftPayrolls,
-} from "./command-api";
-import { fetchSettlementCandidates } from "./read-api";
-import { columns as baseColumns, type PayrollWithWorker } from "./all/columns";
+    columns as baseColumns,
+    type PayrollWithWorker,
+} from "@/app/dashboard/payroll/columns";
 
 const selectableColumns: ColumnDef<PayrollWithWorker>[] = [
     createRowSelectionColumn<PayrollWithWorker>({
@@ -31,14 +29,12 @@ const selectableColumns: ColumnDef<PayrollWithWorker>[] = [
     ...baseColumns,
 ];
 
-export function SettleAllDraftPayrollsButton() {
+export function SettleDraftPayrollsPanel() {
     const router = useRouter();
-    const pathname = usePathname();
-    const [open, setOpen] = React.useState(false);
     const [pending, setPending] = React.useState(false);
     const [downloadingZip, setDownloadingZip] = React.useState(false);
     const [error, setError] = React.useState<string | null>(null);
-    const [loadingDrafts, setLoadingDrafts] = React.useState(false);
+    const [loadingDrafts, setLoadingDrafts] = React.useState(true);
     const [drafts, setDrafts] = React.useState<PayrollWithWorker[]>([]);
     const [rowSelection, setRowSelection] = React.useState<RowSelectionState>(
         {},
@@ -49,37 +45,13 @@ export function SettleAllDraftPayrollsButton() {
         (k) => rowSelection[k],
     ).length;
 
-    const resetSettleDialogUi = React.useCallback(() => {
+    const resetUi = React.useCallback(() => {
         setError(null);
-        setLoadingDrafts(false);
-        setRowSelection({});
     }, []);
-
-    const wasSettleDialogOpen = React.useRef(false);
-    const settleDialogOpenedAtPath = React.useRef<string | null>(null);
-
-    React.useEffect(() => {
-        if (open && !wasSettleDialogOpen.current) {
-            settleDialogOpenedAtPath.current = pathname;
-        }
-        if (!open) {
-            settleDialogOpenedAtPath.current = null;
-        }
-        wasSettleDialogOpen.current = open;
-    }, [open, pathname]);
-
-    React.useEffect(() => {
-        if (!open || settleDialogOpenedAtPath.current === null) return;
-        if (pathname !== settleDialogOpenedAtPath.current) {
-            setOpen(false);
-            resetSettleDialogUi();
-        }
-    }, [pathname, open, resetSettleDialogUi]);
 
     React.useEffect(() => {
         let cancelled = false;
         async function load() {
-            if (!open) return;
             setLoadingDrafts(true);
             setError(null);
             setRowSelection({});
@@ -103,14 +75,13 @@ export function SettleAllDraftPayrollsButton() {
         return () => {
             cancelled = true;
         };
-    }, [open]);
+    }, []);
 
     function getDownloadFilenameFromContentDisposition(
         header: string | null,
     ): string | null {
         if (!header) return null;
 
-        // Prefer RFC5987 `filename*=UTF-8''...`
         const star = header.match(/filename\*\s*=\s*([^;]+)/i);
         if (star?.[1]) {
             const raw = star[1].trim();
@@ -124,7 +95,6 @@ export function SettleAllDraftPayrollsButton() {
             }
         }
 
-        // Fallback to `filename="..."`
         const plain = header.match(/filename\s*=\s*([^;]+)/i);
         if (plain?.[1]) {
             return plain[1].trim().replace(/^"(.*)"$/, "$1");
@@ -185,66 +155,39 @@ export function SettleAllDraftPayrollsButton() {
             }
         }
 
-        setOpen(false);
-        resetSettleDialogUi();
+        resetUi();
         router.refresh();
     }
 
     return (
-        <Dialog
-            open={open}
-            onOpenChange={(nextOpen) => {
-                setOpen(nextOpen);
-                if (!nextOpen) {
-                    resetSettleDialogUi();
-                }
-            }}>
-            <DialogTrigger asChild>
-                <Button
-                    type="button"
-                    variant="destructive"
-                    disabled={pending || downloadingZip}>
-                    Settle all Draft payrolls
-                </Button>
-            </DialogTrigger>
-            <DialogContent className="w-[95vw] max-w-[95vw] sm:max-w-6xl [&_button]:cursor-pointer">
-                <DialogHeader>
-                    <DialogTitle>Confirm settlement</DialogTitle>
-                    <DialogDescription>
-                        {loadingDrafts
-                            ? "Loading Draft payrolls…"
-                            : draftCount === 0
-                              ? "There are no Draft payrolls to settle."
-                              : "Select the Draft payrolls you want to settle. All rows are selected by default."}
-                    </DialogDescription>
-                </DialogHeader>
-                <div className="space-y-2">
-                    <DataTable
-                        columns={selectableColumns}
-                        data={drafts as PayrollWithWorker[]}
-                        syncSearchToUrl={false}
-                        pageSize={5}
-                        enableRowSelection
-                        rowSelection={rowSelection}
-                        onRowSelectionChange={setRowSelection}
-                        getRowId={(row) => row.id}
-                        isLoading={loadingDrafts}
-                        skeletonColumnCount={selectableColumns.length}
-                        skeletonRowCount={10}
-                    />
-                </div>
+        <Card>
+            <CardHeader>
+                <CardTitle>Confirm settlement</CardTitle>
+                <CardDescription>
+                    {loadingDrafts
+                        ? "Loading Draft payrolls…"
+                        : draftCount === 0
+                          ? "There are no Draft payrolls to settle."
+                          : "Select the Draft payrolls you want to settle. All rows are selected by default."}
+                </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+                <DataTable
+                    columns={selectableColumns}
+                    data={drafts as PayrollWithWorker[]}
+                    syncSearchToUrl={false}
+                    enableRowSelection
+                    rowSelection={rowSelection}
+                    onRowSelectionChange={setRowSelection}
+                    getRowId={(row) => row.id}
+                    isLoading={loadingDrafts}
+                    skeletonColumnCount={selectableColumns.length}
+                    skeletonRowCount={20}
+                />
                 {error ? (
                     <p className="text-sm text-destructive">{error}</p>
                 ) : null}
-                <DialogFooter>
-                    <DialogClose asChild>
-                        <Button
-                            type="button"
-                            variant="outline"
-                            disabled={pending || downloadingZip}>
-                            Cancel
-                        </Button>
-                    </DialogClose>
+                <div className="flex flex-wrap justify-end gap-2">
                     <Button
                         type="button"
                         variant="destructive"
@@ -261,8 +204,8 @@ export function SettleAllDraftPayrollsButton() {
                               ? "Preparing ZIP..."
                               : `Settle selected (${selectedCount})`}
                     </Button>
-                </DialogFooter>
-            </DialogContent>
-        </Dialog>
+                </div>
+            </CardContent>
+        </Card>
     );
 }

--- a/app/dashboard/worker/all/worker-all-table-loader.tsx
+++ b/app/dashboard/worker/all/worker-all-table-loader.tsx
@@ -39,24 +39,5 @@ export async function WorkerAllTableLoader() {
         )
         .orderBy(desc(workerTable.updatedAt))) as WorkerWithEmployment[];
 
-    const workersForMassEdit = workers
-        .filter(
-            (worker) =>
-                worker.status === "Active" &&
-                worker.employmentType === "Full Time" &&
-                worker.employmentArrangement === "Foreign Worker",
-        )
-        .map((worker) => ({
-            id: worker.id,
-            name: worker.name,
-            employmentArrangement: worker.employmentArrangement,
-            minimumWorkingHours: worker.minimumWorkingHours,
-        }));
-
-    return (
-        <WorkerAllTableSection
-            workers={workers}
-            workersForMassEdit={workersForMassEdit}
-        />
-    );
+    return <WorkerAllTableSection workers={workers} />;
 }

--- a/app/dashboard/worker/all/worker-all-table-section.tsx
+++ b/app/dashboard/worker/all/worker-all-table-section.tsx
@@ -1,58 +1,39 @@
 "use client";
 
-import * as React from "react";
 import Link from "next/link";
-import { Plus } from "lucide-react";
+import { ListChecks, Plus } from "lucide-react";
 
 import { DataTable } from "@/components/data-table/data-table";
 import { Button } from "@/components/ui/button";
-import { MassEditWorkingHoursButton } from "@/app/dashboard/worker/mass-edit/mass-edit-working-hours-button";
 import { columns } from "./columns";
 import type { WorkerWithEmployment } from "@/db/tables/workerTable";
-import type { WorkerEmploymentArrangement } from "@/types/status";
-import {
-    MassEditWorkingHoursResultTable,
-    type MassEditWorkingHoursResultRow,
-} from "@/app/dashboard/worker/mass-edit/mass-edit-working-hours-result-table";
 
 export function WorkerAllTableSection({
     workers,
-    workersForMassEdit,
 }: {
     workers: WorkerWithEmployment[];
-    workersForMassEdit: Array<{
-        id: string;
-        name: string;
-        employmentArrangement: WorkerEmploymentArrangement;
-        minimumWorkingHours: number | null;
-    }>;
 }) {
-    const [massEditResults, setMassEditResults] = React.useState<
-        MassEditWorkingHoursResultRow[]
-    >([]);
-
     return (
-        <div className="space-y-4">
-            <MassEditWorkingHoursResultTable rows={massEditResults} />
-            <DataTable
-                columns={columns}
-                data={workers}
-                searchParamKey="search"
-                actions={
-                    <div className="flex flex-wrap items-center gap-2">
-                        <Button asChild>
-                            <Link href="/dashboard/worker/new">
-                                <Plus className="mr-2 h-4 w-4" />
-                                New worker
-                            </Link>
-                        </Button>
-                        <MassEditWorkingHoursButton
-                            workers={workersForMassEdit}
-                            onResult={setMassEditResults}
-                        />
-                    </div>
-                }
-            />
-        </div>
+        <DataTable
+            columns={columns}
+            data={workers}
+            searchParamKey="search"
+            actions={
+                <div className="flex flex-wrap items-center gap-2">
+                    <Button asChild>
+                        <Link href="/dashboard/worker/new">
+                            <Plus className="mr-2 h-4 w-4" />
+                            New worker
+                        </Link>
+                    </Button>
+                    <Button variant="outline" asChild>
+                        <Link href="/dashboard/worker/mass-edit">
+                            <ListChecks className="mr-2 h-4 w-4" />
+                            Mass edit working hours
+                        </Link>
+                    </Button>
+                </div>
+            }
+        />
     );
 }

--- a/app/dashboard/worker/mass-edit/get-workers-for-mass-edit.ts
+++ b/app/dashboard/worker/mass-edit/get-workers-for-mass-edit.ts
@@ -3,11 +3,17 @@ import { and, asc, eq } from "drizzle-orm";
 import { employmentTable } from "@/db/tables/employmentTable";
 import { workerTable } from "@/db/tables/workerTable";
 import { db } from "@/lib/db";
-import type { WorkerEmploymentArrangement } from "@/types/status";
+import type {
+    WorkerEmploymentArrangement,
+    WorkerEmploymentType,
+    WorkerStatus,
+} from "@/types/status";
 
 export type WorkerForMassEditWorkingHours = {
     id: string;
     name: string;
+    status: WorkerStatus;
+    employmentType: WorkerEmploymentType;
     employmentArrangement: WorkerEmploymentArrangement;
     minimumWorkingHours: number | null;
 };
@@ -19,6 +25,8 @@ export async function getWorkersForMassEditWorkingHours(): Promise<
         .select({
             id: workerTable.id,
             name: workerTable.name,
+            status: workerTable.status,
+            employmentType: employmentTable.employmentType,
             employmentArrangement: employmentTable.employmentArrangement,
             minimumWorkingHours: employmentTable.minimumWorkingHours,
         })
@@ -39,6 +47,8 @@ export async function getWorkersForMassEditWorkingHours(): Promise<
     return rows.map((row) => ({
         id: row.id,
         name: row.name,
+        status: row.status,
+        employmentType: row.employmentType,
         employmentArrangement: row.employmentArrangement,
         minimumWorkingHours:
             row.minimumWorkingHours != null

--- a/app/dashboard/worker/mass-edit/mass-edit-page-client.tsx
+++ b/app/dashboard/worker/mass-edit/mass-edit-page-client.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { FormPageLayout } from "@/components/form-page-layout";
+
+import {
+    MassEditWorkingHoursPanel,
+    type WorkerForMassEdit,
+} from "./mass-edit-working-hours-panel";
+
+export function MassEditWorkingHoursPageClient({
+    workers,
+}: {
+    workers: WorkerForMassEdit[];
+}) {
+    return (
+        <FormPageLayout
+            title="Mass edit working hours"
+            subtitle="Select workers and set their minimum working hours. Only Active Full Time Foreign Workers are shown."
+            maxWidthClassName="max-w-screen-2xl">
+            <MassEditWorkingHoursPanel workers={workers} />
+        </FormPageLayout>
+    );
+}

--- a/app/dashboard/worker/mass-edit/mass-edit-working-hours-panel.test.tsx
+++ b/app/dashboard/worker/mass-edit/mass-edit-working-hours-panel.test.tsx
@@ -1,0 +1,47 @@
+/** @vitest-environment jsdom */
+
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+
+vi.mock("next/navigation", () => ({
+    useRouter: () => ({ refresh: vi.fn() }),
+    usePathname: () => "/dashboard/worker/mass-edit",
+    useSearchParams: () => new URLSearchParams(),
+}));
+
+import { MassEditWorkingHoursPanel } from "./mass-edit-working-hours-panel";
+
+afterEach(() => {
+    cleanup();
+});
+
+describe("MassEditWorkingHoursPanel", () => {
+    it("renders description and worker table when workers are provided", () => {
+        render(
+            <MassEditWorkingHoursPanel
+                workers={[
+                    {
+                        id: "w1",
+                        name: "Test Worker",
+                        status: "Active",
+                        employmentType: "Full Time",
+                        employmentArrangement: "Foreign Worker",
+                        minimumWorkingHours: 250,
+                    },
+                ]}
+            />,
+        );
+
+        expect(
+            screen.getByText(
+                "Select workers and set their minimum working hours. Only Active Full Time Foreign Workers are shown.",
+            ),
+        ).toBeDefined();
+        expect(screen.getByText("Test Worker")).toBeDefined();
+        expect(screen.getByText("Shared minimum hours")).toBeDefined();
+        expect(
+            screen.getByRole("button", { name: /Save selected/ }),
+        ).toBeDefined();
+    });
+});

--- a/app/dashboard/worker/mass-edit/mass-edit-working-hours-panel.tsx
+++ b/app/dashboard/worker/mass-edit/mass-edit-working-hours-panel.tsx
@@ -3,7 +3,6 @@
 import * as React from "react";
 import type { ColumnDef } from "@tanstack/react-table";
 import type { RowSelectionState } from "@tanstack/react-table";
-import { ListChecks } from "lucide-react";
 import { useRouter } from "next/navigation";
 
 import { DataTable } from "@/components/data-table/data-table";
@@ -14,24 +13,35 @@ import {
 } from "@/components/data-table/column-builders";
 import { Button } from "@/components/ui/button";
 import {
-    Dialog,
-    DialogClose,
-    DialogContent,
-    DialogDescription,
-    DialogFooter,
-    DialogHeader,
-    DialogTitle,
-    DialogTrigger,
-} from "@/components/ui/dialog";
+    Card,
+    CardContent,
+    CardDescription,
+    CardFooter,
+    CardHeader,
+    CardTitle,
+} from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
-import type { MassEditWorkingHoursResultRow } from "./mass-edit-working-hours-result-table";
+import {
+    MassEditWorkingHoursResultTable,
+    type MassEditWorkingHoursResultRow,
+} from "./mass-edit-working-hours-result-table";
 import { updateWorkerMinimumWorkingHours } from "./update-worker-minimum-working-hours";
-import { employmentArrangementBadgeTone } from "@/types/badge-tones";
-import type { WorkerEmploymentArrangement } from "@/types/status";
+import {
+    employmentArrangementBadgeTone,
+    employmentTypeBadgeTone,
+    workerStatusBadgeTone,
+} from "@/types/badge-tones";
+import type {
+    WorkerEmploymentArrangement,
+    WorkerEmploymentType,
+    WorkerStatus,
+} from "@/types/status";
 
-type WorkerForMassEdit = {
+export type WorkerForMassEdit = {
     id: string;
     name: string;
+    status: WorkerStatus;
+    employmentType: WorkerEmploymentType;
     employmentArrangement: WorkerEmploymentArrangement;
     minimumWorkingHours: number | null;
 };
@@ -50,15 +60,12 @@ function parseNonNegativeNumber(text: string): number | null {
     return parsed;
 }
 
-export function MassEditWorkingHoursButton({
+export function MassEditWorkingHoursPanel({
     workers,
-    onResult,
 }: {
     workers: WorkerForMassEdit[];
-    onResult?: (rows: MassEditWorkingHoursResultRow[]) => void;
 }) {
     const router = useRouter();
-    const [open, setOpen] = React.useState(false);
     const [pending, setPending] = React.useState(false);
     const [rowSelection, setRowSelection] = React.useState<RowSelectionState>(
         {},
@@ -68,7 +75,10 @@ export function MassEditWorkingHoursButton({
     >({});
     const [nameFilter, setNameFilter] = React.useState("");
     const [sharedHoursInput, setSharedHoursInput] = React.useState("");
-    const [dialogError, setDialogError] = React.useState<string | null>(null);
+    const [saveError, setSaveError] = React.useState<string | null>(null);
+    const [resultRows, setResultRows] = React.useState<
+        MassEditWorkingHoursResultRow[]
+    >([]);
 
     const selectedIds = React.useMemo(
         () => Object.keys(rowSelection).filter((id) => rowSelection[id]),
@@ -105,14 +115,28 @@ export function MassEditWorkingHoursButton({
                 },
             },
             {
-                accessorKey: "minimumWorkingHours",
-                header: createSortableHeader("Current Minimum Hours"),
+                accessorKey: "status",
+                header: createSortableHeader("Status"),
                 enableColumnFilter: false,
                 meta: { globalSearch: false },
-                cell: ({ row }) =>
-                    row.original.minimumWorkingHours != null
-                        ? `${row.original.minimumWorkingHours}h`
-                        : "—",
+                cell: createBadgeCell<WorkerForMassEdit>({
+                    value: (worker) => worker.status,
+                    variant: "outline",
+                    toneClassNameFor: (worker) =>
+                        workerStatusBadgeTone[worker.status],
+                }),
+            },
+            {
+                accessorKey: "employmentType",
+                header: createSortableHeader("Employment Type"),
+                enableColumnFilter: false,
+                meta: { globalSearch: false },
+                cell: createBadgeCell<WorkerForMassEdit>({
+                    value: (worker) => worker.employmentType,
+                    variant: "outline",
+                    toneClassNameFor: (worker) =>
+                        employmentTypeBadgeTone[worker.employmentType],
+                }),
             },
             {
                 accessorKey: "employmentArrangement",
@@ -127,6 +151,16 @@ export function MassEditWorkingHoursButton({
                             worker.employmentArrangement
                         ],
                 }),
+            },
+            {
+                accessorKey: "minimumWorkingHours",
+                header: createSortableHeader("Current Minimum Hours"),
+                enableColumnFilter: false,
+                meta: { globalSearch: false },
+                cell: ({ row }) =>
+                    row.original.minimumWorkingHours != null
+                        ? `${row.original.minimumWorkingHours}h`
+                        : "—",
             },
             {
                 id: "newMinimumWorkingHours",
@@ -165,33 +199,24 @@ export function MassEditWorkingHoursButton({
         [nameFilter, nextHoursByWorkerId, pending],
     );
 
-    const resetDialogState = React.useCallback(() => {
-        setDialogError(null);
+    const resetFormState = React.useCallback(() => {
+        setSaveError(null);
         setNameFilter("");
         setSharedHoursInput("");
         setNextHoursByWorkerId({});
         setRowSelection({});
     }, []);
 
-    const handleOpenChange = (nextOpen: boolean) => {
-        setOpen(nextOpen);
-        if (nextOpen) {
-            resetDialogState();
-            return;
-        }
-        setDialogError(null);
-    };
-
     const handleApplySharedValue = () => {
-        setDialogError(null);
+        setSaveError(null);
         const parsed = parseNonNegativeNumber(sharedHoursInput);
         if (parsed == null) {
-            setDialogError("Enter a non-negative number before applying.");
+            setSaveError("Enter a non-negative number before applying.");
             return;
         }
 
         if (selectedCount === 0) {
-            setDialogError("Select at least one worker before applying.");
+            setSaveError("Select at least one worker before applying.");
             return;
         }
 
@@ -206,10 +231,10 @@ export function MassEditWorkingHoursButton({
     };
 
     const handleSave = async () => {
-        setDialogError(null);
+        setSaveError(null);
 
         if (selectedCount === 0) {
-            setDialogError("Select at least one worker to update.");
+            setSaveError("Select at least one worker to update.");
             return;
         }
 
@@ -258,7 +283,7 @@ export function MassEditWorkingHoursButton({
                     : { updatedCount: 0, failed: [] as MassEditFailure[] };
 
             if ("error" in result) {
-                setDialogError(result.error);
+                setSaveError(result.error);
                 return;
             }
 
@@ -275,7 +300,7 @@ export function MassEditWorkingHoursButton({
                 ]),
             );
 
-            const resultRows: MassEditWorkingHoursResultRow[] =
+            const nextResultRows: MassEditWorkingHoursResultRow[] =
                 selectedWorkers.map((worker) => {
                     const failed =
                         clientFailuresByWorkerId.has(worker.id) ||
@@ -292,96 +317,88 @@ export function MassEditWorkingHoursButton({
                     };
                 });
 
-            onResult?.(resultRows);
-            setOpen(false);
+            setResultRows(nextResultRows);
+            resetFormState();
             if (result.updatedCount > 0) {
                 router.refresh();
             }
         } catch (error) {
             console.error("Failed to mass edit working hours", error);
-            setDialogError("Failed to save mass edit. Please try again.");
+            setSaveError("Failed to save mass edit. Please try again.");
         } finally {
             setPending(false);
         }
     };
 
     return (
-        <Dialog open={open} onOpenChange={handleOpenChange}>
-            <DialogTrigger asChild>
-                <Button type="button" variant="outline">
-                    <ListChecks className="mr-2 h-4 w-4" />
-                    Mass edit working hours
-                </Button>
-            </DialogTrigger>
-            <DialogContent className="flex max-h-[90vh] w-[calc(100vw-2rem)] max-w-[calc(100vw-2rem)] flex-col sm:max-w-[calc(100vw-2rem)] [&_button]:cursor-pointer">
-                <DialogHeader>
-                    <DialogTitle>Mass edit working hours</DialogTitle>
-                    <DialogDescription>
+        <div
+            className="space-y-6"
+            data-testid="mass-edit-working-hours-panel">
+            <MassEditWorkingHoursResultTable rows={resultRows} />
+
+            <Card>
+                <CardHeader>
+                    <CardTitle>Mass edit working hours</CardTitle>
+                    <CardDescription>
                         Select workers and set their minimum working hours. Only
                         Active Full Time Foreign Workers are shown.
-                    </DialogDescription>
-                </DialogHeader>
+                    </CardDescription>
+                </CardHeader>
 
-                <div className="flex flex-wrap items-end gap-2 rounded-md border p-3">
-                    <div className="space-y-1">
-                        <label
-                            htmlFor="mass-edit-shared-hours"
-                            className="text-xs font-medium text-muted-foreground">
-                            Shared minimum hours
-                        </label>
-                        <Input
-                            id="mass-edit-shared-hours"
-                            inputMode="decimal"
-                            value={sharedHoursInput}
-                            onChange={(event) =>
-                                setSharedHoursInput(event.target.value)
-                            }
-                            placeholder="e.g. 260"
-                            disabled={pending}
-                            className="h-8 w-40 text-right text-xs"
-                        />
-                    </div>
-                    <Button
-                        type="button"
-                        size="sm"
-                        variant="outline"
-                        disabled={pending}
-                        onClick={handleApplySharedValue}>
-                        Apply to selected
-                    </Button>
-                    <p className="text-xs text-muted-foreground">
-                        {selectedCount} worker
-                        {selectedCount !== 1 ? "s" : ""} selected
-                    </p>
-                </div>
-
-                <div className="min-h-0 min-w-0 flex-1 overflow-y-auto overflow-x-auto">
-                    <DataTable
-                        columns={columns}
-                        data={filteredWorkers}
-                        syncSearchToUrl={false}
-                        showGlobalSearch={false}
-                        pageSize={20}
-                        enableRowSelection
-                        rowSelection={rowSelection}
-                        onRowSelectionChange={setRowSelection}
-                        getRowId={(row) => row.id}
-                    />
-                </div>
-
-                {dialogError ? (
-                    <p className="text-sm text-destructive">{dialogError}</p>
-                ) : null}
-
-                <DialogFooter>
-                    <DialogClose asChild>
+                <CardContent className="space-y-4">
+                    <div className="flex flex-wrap items-end gap-2 rounded-md border p-3">
+                        <div className="space-y-1">
+                            <label
+                                htmlFor="mass-edit-shared-hours"
+                                className="text-xs font-medium text-muted-foreground">
+                                Shared minimum hours
+                            </label>
+                            <Input
+                                id="mass-edit-shared-hours"
+                                inputMode="decimal"
+                                value={sharedHoursInput}
+                                onChange={(event) =>
+                                    setSharedHoursInput(event.target.value)
+                                }
+                                placeholder="e.g. 260"
+                                disabled={pending}
+                                className="h-8 w-40 text-right text-xs"
+                            />
+                        </div>
                         <Button
                             type="button"
+                            size="sm"
                             variant="outline"
-                            disabled={pending}>
-                            Cancel
+                            disabled={pending}
+                            onClick={handleApplySharedValue}>
+                            Apply to selected
                         </Button>
-                    </DialogClose>
+                        <p className="text-xs text-muted-foreground">
+                            {selectedCount} worker
+                            {selectedCount !== 1 ? "s" : ""} selected
+                        </p>
+                    </div>
+
+                    <div className="max-h-[min(70vh,720px)] min-h-0 min-w-0 overflow-x-auto overflow-y-auto">
+                        <DataTable
+                            columns={columns}
+                            data={filteredWorkers}
+                            syncSearchToUrl={false}
+                            showGlobalSearch={false}
+                            pageSize={20}
+                            enableRowSelection
+                            rowSelection={rowSelection}
+                            onRowSelectionChange={setRowSelection}
+                            getRowId={(row) => row.id}
+                        />
+                    </div>
+
+                    {saveError ? (
+                        <p className="text-sm text-destructive">{saveError}</p>
+                    ) : null}
+                </CardContent>
+
+                <CardFooter className="justify-end border-t pt-6">
                     <Button
                         type="button"
                         disabled={pending || selectedCount === 0}
@@ -390,8 +407,8 @@ export function MassEditWorkingHoursButton({
                             ? "Saving..."
                             : `Save selected (${selectedCount})`}
                     </Button>
-                </DialogFooter>
-            </DialogContent>
-        </Dialog>
+                </CardFooter>
+            </Card>
+        </div>
     );
 }

--- a/app/dashboard/worker/mass-edit/page.tsx
+++ b/app/dashboard/worker/mass-edit/page.tsx
@@ -1,0 +1,8 @@
+import { getWorkersForMassEditWorkingHours } from "./get-workers-for-mass-edit";
+import { MassEditWorkingHoursPageClient } from "./mass-edit-page-client";
+
+export default async function MassEditWorkingHoursPage() {
+    const workers = await getWorkersForMassEditWorkingHours();
+
+    return <MassEditWorkingHoursPageClient workers={workers} />;
+}

--- a/app/dashboard/worker/page.test.ts
+++ b/app/dashboard/worker/page.test.ts
@@ -11,10 +11,6 @@ vi.mock("@/lib/db", () => ({
     db: mocks.db,
 }));
 
-vi.mock("@/app/dashboard/worker/mass-edit/mass-edit-working-hours-button", () => ({
-    MassEditWorkingHoursButton: () => "<mass-edit-working-hours-button />",
-}));
-
 import { WorkerOverviewLoader } from "@/app/dashboard/worker/worker-overview-loader";
 
 describe("WorkerOverviewLoader", () => {
@@ -31,15 +27,6 @@ describe("WorkerOverviewLoader", () => {
                 from: vi.fn().mockReturnValue({
                     where: vi.fn().mockResolvedValue([{ active: 3 }]),
                 }),
-            })
-            .mockReturnValueOnce({
-                from: vi.fn().mockReturnValue({
-                    innerJoin: vi.fn().mockReturnValue({
-                        where: vi.fn().mockReturnValue({
-                            orderBy: vi.fn().mockResolvedValue([]),
-                        }),
-                    }),
-                }),
             });
 
         const html = renderToStaticMarkup(await WorkerOverviewLoader());
@@ -49,6 +36,8 @@ describe("WorkerOverviewLoader", () => {
         expect(html).toContain("3 Active, 2 Inactive");
         expect(html).toContain("View all workers");
         expect(html).toContain("New worker");
+        expect(html).toContain("Mass edit working hours");
+        expect(html).toContain('href="/dashboard/worker/mass-edit"');
         expect(html).toContain("Status breakdown");
     });
 });

--- a/app/dashboard/worker/worker-overview-loader.tsx
+++ b/app/dashboard/worker/worker-overview-loader.tsx
@@ -3,7 +3,6 @@ import { count, eq } from "drizzle-orm";
 
 import { db } from "@/lib/db";
 import { workerTable } from "@/db/tables/workerTable";
-import { getWorkersForMassEditWorkingHours } from "@/app/dashboard/worker/mass-edit/get-workers-for-mass-edit";
 import { Button } from "@/components/ui/button";
 import {
     Card,
@@ -13,17 +12,15 @@ import {
     CardTitle,
 } from "@/components/ui/card";
 import { SimpleDonutChart } from "@/components/dashboard/simple-donut-chart";
-import { ArrowRight, Plus, Users } from "lucide-react";
-import { MassEditWorkingHoursButton } from "./mass-edit/mass-edit-working-hours-button";
+import { ArrowRight, ListChecks, Plus, Users } from "lucide-react";
 
 export async function WorkerOverviewLoader() {
-    const [[{ total }], [{ active }], workersForMassEdit] = await Promise.all([
+    const [[{ total }], [{ active }]] = await Promise.all([
         db.select({ total: count() }).from(workerTable),
         db
             .select({ active: count() })
             .from(workerTable)
             .where(eq(workerTable.status, "Active")),
-        getWorkersForMassEditWorkingHours(),
     ]);
 
     const inactive = Number(total) - Number(active);
@@ -60,7 +57,12 @@ export async function WorkerOverviewLoader() {
                         New worker
                     </Link>
                 </Button>
-                <MassEditWorkingHoursButton workers={workersForMassEdit} />
+                <Button variant="outline" asChild>
+                    <Link href="/dashboard/worker/mass-edit">
+                        <ListChecks className="mr-2 h-4 w-4" />
+                        Mass edit working hours
+                    </Link>
+                </Button>
             </div>
 
             <Card>

--- a/components/data-table/data-table.selection-prune.test.tsx
+++ b/components/data-table/data-table.selection-prune.test.tsx
@@ -1,0 +1,79 @@
+/** @vitest-environment jsdom */
+
+import React from "react";
+import type { ColumnDef } from "@tanstack/react-table";
+import type { RowSelectionState } from "@tanstack/react-table";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+vi.mock("next/navigation", () => ({
+    useRouter: () => ({ replace: vi.fn() }),
+    usePathname: () => "/dashboard/test",
+    useSearchParams: () => new URLSearchParams(),
+}));
+
+import { DataTable } from "./data-table";
+
+type Row = { id: string; name: string };
+
+const columns: ColumnDef<Row>[] = [
+    {
+        accessorKey: "name",
+        header: "Name",
+    },
+];
+
+const sampleData: Row[] = [
+    { id: "a", name: "Alpha" },
+    { id: "b", name: "Beta" },
+];
+
+afterEach(() => {
+    cleanup();
+});
+
+describe("DataTable selection prune on filter", () => {
+    it("removes selected row IDs that no longer pass the global filter", async () => {
+        const user = userEvent.setup();
+        const latestSelection = { current: null as RowSelectionState | null };
+
+        function Harness() {
+            const [rowSelection, setRowSelection] =
+                React.useState<RowSelectionState>({
+                    a: true,
+                    b: true,
+                });
+            latestSelection.current = rowSelection;
+            return (
+                <DataTable<Row, unknown>
+                    columns={columns}
+                    data={sampleData}
+                    enableRowSelection
+                    getRowId={(row) => row.id}
+                    rowSelection={rowSelection}
+                    onRowSelectionChange={(updater) => {
+                        setRowSelection((prev) => {
+                            const next =
+                                typeof updater === "function"
+                                    ? updater(prev)
+                                    : updater;
+                            return next;
+                        });
+                    }}
+                    syncSearchToUrl={false}
+                />
+            );
+        }
+
+        render(<Harness />);
+
+        const search = screen.getByPlaceholderText("Search...");
+        await user.clear(search);
+        await user.type(search, "Beta");
+
+        await waitFor(() => {
+            expect(latestSelection.current).toEqual({ b: true });
+        });
+    });
+});

--- a/components/data-table/data-table.tsx
+++ b/components/data-table/data-table.tsx
@@ -14,6 +14,7 @@ import {
     type Row,
     type RowSelectionState,
     SortingState,
+    type Table as TanStackTable,
     useReactTable,
 } from "@tanstack/react-table";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
@@ -69,6 +70,11 @@ interface DataTableProps<TData, TValue> {
     skeletonColumnCount?: number;
     /** Row count for the loading skeleton (defaults to 10). */
     skeletonRowCount?: number;
+    /**
+     * When row selection is enabled, drop selected row IDs that no longer pass
+     * column/global filters (or are absent from `data`) whenever filters or data change.
+     */
+    pruneRowSelectionOnFilterChange?: boolean;
 }
 
 type ColumnMeta = ColumnFilterMeta & { globalSearch?: boolean };
@@ -119,6 +125,7 @@ export function DataTable<TData, TValue>({
     isLoading = false,
     skeletonColumnCount,
     skeletonRowCount = 10,
+    pruneRowSelectionOnFilterChange = true,
 }: DataTableProps<TData, TValue>) {
     const searchParams = useSearchParams();
     const pathname = usePathname();
@@ -249,6 +256,53 @@ export function DataTable<TData, TValue>({
             });
         },
     });
+
+    const tableRef = React.useRef<TanStackTable<TData>>(null!);
+    tableRef.current = table;
+
+    React.useEffect(() => {
+        if (
+            !enableRowSelection ||
+            !onRowSelectionChange ||
+            !pruneRowSelectionOnFilterChange ||
+            isLoading
+        ) {
+            return;
+        }
+
+        const allowedIds = new Set(
+            tableRef.current
+                .getFilteredRowModel()
+                .rows.map((row) => row.id),
+        );
+
+        onRowSelectionChange((prev) => {
+            let needsPrune = false;
+            for (const id of Object.keys(prev)) {
+                if (prev[id] && !allowedIds.has(id)) {
+                    needsPrune = true;
+                    break;
+                }
+            }
+            if (!needsPrune) return prev;
+
+            const next: RowSelectionState = {};
+            for (const id of Object.keys(prev)) {
+                if (prev[id] && allowedIds.has(id)) {
+                    next[id] = true;
+                }
+            }
+            return next;
+        });
+    }, [
+        columnFilters,
+        globalFilter,
+        data,
+        isLoading,
+        enableRowSelection,
+        onRowSelectionChange,
+        pruneRowSelectionOnFilterChange,
+    ]);
 
     const canSearchAnyColumn = table
         .getVisibleLeafColumns()

--- a/components/ui/progress.tsx
+++ b/components/ui/progress.tsx
@@ -1,0 +1,31 @@
+"use client"
+
+import * as React from "react"
+import { Progress as ProgressPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Progress({
+  className,
+  value,
+  ...props
+}: React.ComponentProps<typeof ProgressPrimitive.Root>) {
+  return (
+    <ProgressPrimitive.Root
+      data-slot="progress"
+      className={cn(
+        "relative h-2 w-full overflow-hidden rounded-full bg-primary/20",
+        className
+      )}
+      {...props}
+    >
+      <ProgressPrimitive.Indicator
+        data-slot="progress-indicator"
+        className="h-full w-full flex-1 bg-primary transition-all"
+        style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
+      />
+    </ProgressPrimitive.Root>
+  )
+}
+
+export { Progress }

--- a/test/e2e/payroll-dialog-navigation.spec.ts
+++ b/test/e2e/payroll-dialog-navigation.spec.ts
@@ -14,6 +14,13 @@ async function requireRowActionOrSkip(scope: Locator) {
     return actionButton;
 }
 
+async function clickRowActionView(page: Page) {
+    const openMenu = page.locator(
+        '[data-slot="dropdown-menu-content"][data-state="open"]',
+    );
+    await openMenu.getByRole("menuitem", { name: "View" }).click();
+}
+
 async function assertPageStillInteractive(page: Page) {
     const bodyPointerEvents = await page.evaluate(
         () => getComputedStyle(document.body).pointerEvents,
@@ -29,23 +36,27 @@ async function assertPageStillInteractive(page: Page) {
     await expect(page).toHaveURL(/\/dashboard\/payroll$/);
 }
 
-test.describe("Payroll dialog navigation", () => {
-    test("Download payrolls dialog view navigation does not lock page", async ({
+test.describe("Payroll download page navigation", () => {
+    test.describe.configure({ mode: "serial" });
+
+    test("Download payrolls page view navigation does not lock page", async ({
         page,
     }) => {
         await page.goto("/dashboard/payroll");
         await expect(page).toHaveURL(/\/dashboard\/payroll$/);
 
-        await page.getByRole("button", { name: "Download payrolls" }).click();
-        const dialog = page.getByRole("dialog");
-        await expect(dialog).toBeVisible();
-        await expect(dialog.getByRole("table")).toBeVisible({ timeout: 25_000 });
+        await page
+            .locator("main")
+            .getByRole("link", { name: "Download payrolls" })
+            .click();
+        await expect(page).toHaveURL(/\/dashboard\/payroll\/download-payrolls$/);
 
-        const actionButton = await requireRowActionOrSkip(
-            dialog.getByRole("table"),
-        );
+        const payrollTable = page.locator("main").getByRole("table");
+        await expect(payrollTable).toBeVisible({ timeout: 25_000 });
+
+        const actionButton = await requireRowActionOrSkip(payrollTable);
         await actionButton.click();
-        await page.getByRole("menuitem", { name: "View" }).click();
+        await clickRowActionView(page);
 
         await expect(page).toHaveURL(
             /\/dashboard\/payroll\/[0-9a-f-]+\/breakdown$/i,
@@ -65,7 +76,7 @@ test.describe("Payroll dialog navigation", () => {
 
         const actionButton = await requireRowActionOrSkip(payrollTable);
         await actionButton.click();
-        await page.getByRole("menuitem", { name: "View" }).click();
+        await clickRowActionView(page);
 
         await expect(page).toHaveURL(
             /\/dashboard\/payroll\/[0-9a-f-]+\/breakdown$/i,

--- a/test/e2e/worker-mass-edit-working-hours.spec.ts
+++ b/test/e2e/worker-mass-edit-working-hours.spec.ts
@@ -9,33 +9,27 @@ test.describe("Worker mass edit minimum hours", () => {
     test("updates a foreign full-time worker via mass edit and shows result table", async ({
         page,
     }) => {
-        await page.goto("/dashboard/worker/all");
+        await page.goto("/dashboard/worker/mass-edit");
         await assertOpenDashboardAccess(page);
 
         await expect(
-            page.getByRole("heading", { name: "All workers" }),
+            page.getByRole("heading", { name: "Mass edit working hours" }),
         ).toBeVisible();
         await expect(
-            page.getByRole("button", { name: "Mass edit working hours" }),
+            page.getByText(
+                "Only Active Full Time Foreign Workers are shown.",
+            ),
         ).toBeVisible();
 
-        await page
-            .getByRole("button", { name: "Mass edit working hours" })
-            .click();
-        const dialog = page.getByRole("dialog");
-        await expect(dialog).toBeVisible();
-        await expect(
-            dialog.getByText("Only Active Full Time Foreign Workers are shown."),
-        ).toBeVisible();
-
-        const workerFilterInput = dialog
+        const panel = page.getByTestId("mass-edit-working-hours-panel");
+        const workerFilterInput = panel
             .locator("thead tr")
             .nth(1)
             .getByPlaceholder("Filter...");
         await workerFilterInput.fill(WORKER_FIXTURE_NAMES.massEditTarget);
 
         await expect(
-            dialog
+            panel
                 .getByRole("cell", {
                     name: WORKER_FIXTURE_NAMES.massEditTarget,
                     exact: true,
@@ -43,13 +37,13 @@ test.describe("Worker mass edit minimum hours", () => {
                 .first(),
         ).toBeVisible();
 
-        const targetWorkerCheckbox = dialog.getByRole("checkbox", {
+        const targetWorkerCheckbox = panel.getByRole("checkbox", {
             name: `Select ${WORKER_FIXTURE_NAMES.massEditTarget}`,
         }).first();
         await targetWorkerCheckbox.click();
 
-        await dialog.getByLabel("Shared minimum hours").fill("250");
-        await dialog.getByRole("button", { name: "Apply to selected" }).click();
+        await panel.getByLabel("Shared minimum hours").fill("250");
+        await panel.getByRole("button", { name: "Apply to selected" }).click();
 
         await targetWorkerCheckbox
             .locator("xpath=ancestor::tr[1]")
@@ -58,11 +52,10 @@ test.describe("Worker mass edit minimum hours", () => {
             )
             .fill("260");
 
-        await dialog.getByRole("button", { name: /Save selected/ }).click();
-        await expect(dialog).not.toBeVisible({ timeout: 60_000 });
+        await panel.getByRole("button", { name: /Save selected/ }).click();
 
         const results = page.getByTestId("mass-edit-working-hours-results");
-        await expect(results).toBeVisible();
+        await expect(results).toBeVisible({ timeout: 60_000 });
         await expect(
             results
                 .getByRole("cell", {

--- a/utils/nav/dashboard-nav-features.ts
+++ b/utils/nav/dashboard-nav-features.ts
@@ -40,6 +40,10 @@ export const DASHBOARD_NAV_FEATURES: DashboardNavFeature[] = [
         subFeatures: [
             { name: "All workers", url: "/dashboard/worker/all" },
             { name: "New worker", url: "/dashboard/worker/new" },
+            {
+                name: "Mass edit working hours",
+                url: "/dashboard/worker/mass-edit",
+            },
         ],
         iconName: "Worker",
     },
@@ -80,6 +84,11 @@ export const DASHBOARD_NAV_FEATURES: DashboardNavFeature[] = [
         subFeatures: [
             { name: "All payrolls", url: "/dashboard/payroll/all" },
             { name: "New payroll", url: "/dashboard/payroll/new" },
+            { name: "Settle drafts", url: "/dashboard/payroll/settle-drafts" },
+            {
+                name: "Download payrolls",
+                url: "/dashboard/payroll/download-payrolls",
+            },
         ],
         iconName: "Payroll",
     },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,6 +6,15 @@ export default defineConfig({
         environment: "node",
         include: ["{app,components,utils,lib,db,services,scripts}/**/*.test.{ts,tsx}"],
         exclude: ["node_modules", ".next", "test/e2e"],
+        // `lib/db` throws if unset; unit tests import modules that transitively load `db`.
+        // Tests do not require a live Postgres instance unless they execute queries.
+        env: {
+            DATABASE_URL:
+                process.env.DATABASE_URL ??
+                "postgresql://127.0.0.1:5432/vitest_placeholder",
+        },
+        // jsdom + user-event suites can exceed 5s under parallel workers.
+        testTimeout: 15_000,
     },
     resolve: {
         alias: {


### PR DESCRIPTION
…able selection

- Replace payroll download/settle buttons with dedicated routes and panels
- Add worker mass-edit page with working-hours panel and client wrapper
- Extend data-table with selection pruning and tests; add Progress UI
- Update payroll/worker loaders, e2e specs, nav features, and vitest config

Made-with: Cursor