### PR TITLE
feat(payroll): bulk ZIP download with streaming progress UI

### DIFF
--- a/app/api/payroll/download-zip/route.test.ts
+++ b/app/api/payroll/download-zip/route.test.ts
@@ -1,11 +1,46 @@
+import { Buffer } from "node:buffer";
+
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { NextRequest } from "next/server";
 
 import { POST } from "@/app/api/payroll/download-zip/route";
 
+const mocks = vi.hoisted(() => ({
+    db: {
+        select: vi.fn(),
+    },
+}));
+
+vi.mock("@/lib/db", () => ({
+    db: mocks.db,
+}));
+
 describe("POST /api/payroll/download-zip", () => {
     beforeEach(() => {
         vi.clearAllMocks();
+        mocks.db.select.mockReturnValue({
+            from: vi.fn().mockReturnValue({
+                innerJoin: vi.fn().mockReturnValue({
+                    where: vi.fn().mockResolvedValue([
+                        {
+                            id: "payroll-1",
+                            periodStart: "2026-01-01",
+                            periodEnd: "2026-01-31",
+                            workerName: "Alice",
+                        },
+                    ]),
+                }),
+            }),
+        });
+        global.fetch = vi.fn().mockImplementation(async (input: RequestInfo | URL) => {
+            const url = String(input);
+            if (url.includes("/pdf?mode=summary")) {
+                return new Response(new Uint8Array([0x25, 0x50, 0x44, 0x46]), {
+                    status: 200,
+                });
+            }
+            return new Response(null, { status: 404 });
+        });
     });
 
     it("returns INVALID_JSON for malformed payloads", async () => {
@@ -44,5 +79,56 @@ describe("POST /api/payroll/download-zip", () => {
                 details: undefined,
             },
         });
+    });
+
+    it("streams NDJSON with meta, progress, zip frames, and done when progress=1", async () => {
+        const response = await POST(
+            new NextRequest(
+                "http://localhost/api/payroll/download-zip?progress=1",
+                {
+                    method: "POST",
+                    body: JSON.stringify({ payrollIds: ["payroll-1"] }),
+                },
+            ),
+        );
+
+        expect(response.status).toBe(200);
+        expect(response.headers.get("Content-Type")).toBe(
+            "application/x-ndjson",
+        );
+
+        const text = await response.text();
+        const lines = text
+            .trim()
+            .split("\n")
+            .filter((l) => l.length > 0);
+        expect(lines.length).toBeGreaterThanOrEqual(3);
+
+        const first = JSON.parse(lines[0]!) as { type: string; n?: number };
+        expect(first.type).toBe("meta");
+        expect(first.n).toBe(1);
+
+        const progressLines = lines
+            .map((l) => JSON.parse(l) as { type: string })
+            .filter((o) => o.type === "progress");
+        expect(progressLines.length).toBeGreaterThanOrEqual(1);
+
+        let zipBuf = Buffer.alloc(0);
+        for (const line of lines) {
+            const o = JSON.parse(line) as { type: string; data?: string };
+            if (o.type === "zip" && typeof o.data === "string") {
+                zipBuf = Buffer.concat([zipBuf, Buffer.from(o.data, "base64")]);
+            }
+        }
+        expect(zipBuf.length).toBeGreaterThan(0);
+        expect(zipBuf[0]).toBe(0x50);
+        expect(zipBuf[1]).toBe(0x4b);
+
+        const last = JSON.parse(lines[lines.length - 1]!) as {
+            type: string;
+            filename?: string;
+        };
+        expect(last.type).toBe("done");
+        expect(typeof last.filename).toBe("string");
     });
 });

--- a/app/api/payroll/download-zip/route.ts
+++ b/app/api/payroll/download-zip/route.ts
@@ -14,6 +14,13 @@ type Body = { payrollIds?: unknown };
 type PayrollPdfFailure = { payrollId: string; reason: string };
 type PayrollPdfEntry = { name: string; buffer: Buffer };
 
+type PayrollMetaRow = {
+    id: string;
+    periodStart: unknown;
+    periodEnd: unknown;
+    workerName: string;
+};
+
 function safeFilenamePart(s: string): string {
     return String(s).replace(/[/\\:*?"<>|]/g, "-").trim();
 }
@@ -85,6 +92,183 @@ export function createZipFilename(args: {
     );
 }
 
+function enqueueNdjsonLine(
+    controller: ReadableStreamDefaultController<Uint8Array>,
+    encoder: TextEncoder,
+    obj: object,
+) {
+    controller.enqueue(encoder.encode(JSON.stringify(obj) + "\n"));
+}
+
+async function collectPdfEntries(args: {
+    payrollIds: string[];
+    metaById: Map<string, PayrollMetaRow>;
+    cookie: string;
+    origin: string;
+    failures: PayrollPdfFailure[];
+    onProgress?: (i: number, n: number, workerName: string) => void;
+}): Promise<PayrollPdfEntry[]> {
+    const { payrollIds, metaById, cookie, origin, failures, onProgress } = args;
+    const n = payrollIds.length;
+    const pdfEntries: PayrollPdfEntry[] = [];
+    const seenNames = new Map<string, number>();
+
+    for (let idx = 0; idx < payrollIds.length; idx++) {
+        const id = payrollIds[idx]!;
+        const meta = metaById.get(id);
+        const workerNameForProgress = meta?.workerName ?? `payroll-${id}`;
+        try {
+            const url = `${origin}/api/payroll/${id}/pdf?mode=summary`;
+            const res = await fetch(url, {
+                headers: cookie ? { cookie } : undefined,
+                cache: "no-store",
+            });
+            if (!res.ok) {
+                const reason = `PDF failed (${res.status})`;
+                failures.push({ payrollId: id, reason });
+                console.warn(`[payroll/download-zip] Failed to fetch PDF`, {
+                    payrollId: id,
+                    status: res.status,
+                });
+            } else {
+                const buf = Buffer.from(await res.arrayBuffer());
+
+                const workerName = meta?.workerName ?? `payroll-${id}`;
+                const periodStart = isoToDdmmyyyy(isoDate(meta?.periodStart ?? ""));
+                const periodEnd = isoToDdmmyyyy(isoDate(meta?.periodEnd ?? ""));
+                const baseName = createPayrollPdfBaseName({
+                    workerName,
+                    periodStart,
+                    periodEnd,
+                });
+                const uniqueName = makeUniqueZipEntryName(baseName, seenNames);
+                if (uniqueName !== baseName) {
+                    console.warn(`[payroll/download-zip] Duplicate filename collision`, {
+                        payrollId: id,
+                        baseName,
+                        uniqueName,
+                    });
+                }
+
+                pdfEntries.push({
+                    name: uniqueName,
+                    buffer: buf,
+                });
+            }
+        } catch (error) {
+            const reason =
+                error instanceof Error ? error.message : "Unknown error";
+            failures.push({ payrollId: id, reason });
+            console.warn(`[payroll/download-zip] PDF processing error`, {
+                payrollId: id,
+                reason,
+            });
+        }
+        onProgress?.(idx + 1, n, workerNameForProgress);
+    }
+
+    return pdfEntries;
+}
+
+function createNdjsonZipResponseStream(args: {
+    payrollIds: string[];
+    metaById: Map<string, PayrollMetaRow>;
+    cookie: string;
+    origin: string;
+    periodStartForZipLabel: string;
+    periodEndForZipLabel: string;
+}): ReadableStream<Uint8Array> {
+    const {
+        payrollIds,
+        metaById,
+        cookie,
+        origin,
+        periodStartForZipLabel,
+        periodEndForZipLabel,
+    } = args;
+
+    return new ReadableStream<Uint8Array>({
+        async start(controller) {
+            const encoder = new TextEncoder();
+            const enqueueLine = (obj: object) =>
+                enqueueNdjsonLine(controller, encoder, obj);
+
+            try {
+                enqueueLine({ type: "meta", n: payrollIds.length });
+
+                const failures: PayrollPdfFailure[] = [];
+                const pdfEntries = await collectPdfEntries({
+                    payrollIds,
+                    metaById,
+                    cookie,
+                    origin,
+                    failures,
+                    onProgress: (i, n, workerName) => {
+                        enqueueLine({ type: "progress", i, n, workerName });
+                    },
+                });
+
+                const zipName = createZipFilename({
+                    periodStart: periodStartForZipLabel,
+                    periodEnd: periodEndForZipLabel,
+                    partial: failures.length > 0,
+                });
+
+                const zip = archiver("zip", { zlib: { level: 9 } });
+
+                zip.on("data", (chunk: Buffer) => {
+                    enqueueLine({
+                        type: "zip",
+                        data: chunk.toString("base64"),
+                    });
+                });
+
+                await new Promise<void>((resolve, reject) => {
+                    zip.on("end", () => resolve());
+                    zip.on("error", reject);
+                    zip.on("warning", reject);
+                    void (async () => {
+                        try {
+                            for (const entry of pdfEntries) {
+                                zip.append(Readable.from(entry.buffer), {
+                                    name: entry.name,
+                                });
+                            }
+                            if (failures.length > 0) {
+                                const report = formatDownloadErrorsReport(failures);
+                                zip.append(report, {
+                                    name: "_download-errors.txt",
+                                });
+                            }
+                            await zip.finalize();
+                        } catch (e) {
+                            reject(e);
+                        }
+                    })();
+                });
+
+                enqueueLine({
+                    type: "done",
+                    filename: zipName,
+                    failed: failures.length,
+                });
+                controller.close();
+            } catch (e) {
+                enqueueLine({
+                    type: "error",
+                    message:
+                        e instanceof Error ? e.message : "Unknown error",
+                });
+                try {
+                    controller.close();
+                } catch {
+                    /* already closed */
+                }
+            }
+        },
+    });
+}
+
 export async function POST(req: NextRequest) {
     let parsed: Body;
     try {
@@ -126,83 +310,63 @@ export async function POST(req: NextRequest) {
     const ends = payrollMeta.map((m) => isoDate(m.periodEnd));
 
     const periodStartForZip =
-        starts.length > 0 ? starts.slice().sort()[0]! : new Date().toISOString().slice(0, 10);
+        starts.length > 0
+            ? starts.slice().sort()[0]!
+            : new Date().toISOString().slice(0, 10);
     const periodEndForZip =
-        ends.length > 0 ? ends.slice().sort().at(-1)! : new Date().toISOString().slice(0, 10);
+        ends.length > 0
+            ? ends.slice().sort().at(-1)!
+            : new Date().toISOString().slice(0, 10);
 
     const periodStartForZipLabel = isoToDdmmyyyy(periodStartForZip);
     const periodEndForZipLabel = isoToDdmmyyyy(periodEndForZip);
 
     const cookie = req.headers.get("cookie") ?? "";
     const origin = req.nextUrl.origin;
+    const progressNdjson =
+        req.nextUrl.searchParams.get("progress") === "1";
+
+    if (progressNdjson) {
+        const stream = createNdjsonZipResponseStream({
+            payrollIds,
+            metaById,
+            cookie,
+            origin,
+            periodStartForZipLabel,
+            periodEndForZipLabel,
+        });
+
+        return new Response(stream, {
+            headers: {
+                "Content-Type": "application/x-ndjson",
+                "Cache-Control": "no-store",
+            },
+        });
+    }
 
     const failures: PayrollPdfFailure[] = [];
-    const pdfEntries: PayrollPdfEntry[] = [];
-    const seenNames = new Map<string, number>();
-
-    for (const id of payrollIds) {
-        try {
-            const url = `${origin}/api/payroll/${id}/pdf?mode=summary`;
-            const res = await fetch(url, {
-                headers: cookie ? { cookie } : undefined,
-                cache: "no-store",
-            });
-            if (!res.ok) {
-                const reason = `PDF failed (${res.status})`;
-                failures.push({ payrollId: id, reason });
-                console.warn(`[payroll/download-zip] Failed to fetch PDF`, {
-                    payrollId: id,
-                    status: res.status,
-                });
-                continue;
-            }
-            const buf = Buffer.from(await res.arrayBuffer());
-
-            const meta = metaById.get(id);
-            const workerName = meta?.workerName ?? `payroll-${id}`;
-            const periodStart = isoToDdmmyyyy(isoDate(meta?.periodStart ?? ""));
-            const periodEnd = isoToDdmmyyyy(isoDate(meta?.periodEnd ?? ""));
-            const baseName = createPayrollPdfBaseName({
-                workerName,
-                periodStart,
-                periodEnd,
-            });
-            const uniqueName = makeUniqueZipEntryName(baseName, seenNames);
-            if (uniqueName !== baseName) {
-                console.warn(`[payroll/download-zip] Duplicate filename collision`, {
-                    payrollId: id,
-                    baseName,
-                    uniqueName,
-                });
-            }
-
-            pdfEntries.push({
-                name: uniqueName,
-                buffer: buf,
-            });
-        } catch (error) {
-            const reason =
-                error instanceof Error ? error.message : "Unknown error";
-            failures.push({ payrollId: id, reason });
-            console.warn(`[payroll/download-zip] PDF processing error`, {
-                payrollId: id,
-                reason,
-            });
-        }
-    }
+    const pdfEntries = await collectPdfEntries({
+        payrollIds,
+        metaById,
+        cookie,
+        origin,
+        failures,
+    });
 
     const stream = new ReadableStream<Uint8Array>({
         start(controller) {
             const zip = archiver("zip", { zlib: { level: 9 } });
 
-            zip.on("data", (chunk: Buffer) => controller.enqueue(new Uint8Array(chunk)));
+            zip.on("data", (chunk: Buffer) =>
+                controller.enqueue(new Uint8Array(chunk)),
+            );
             zip.on("end", () => controller.close());
             zip.on("warning", (err: unknown) => {
                 controller.error(err);
             });
             zip.on("error", (err: unknown) => controller.error(err));
 
-            (async () => {
+            void (async () => {
                 try {
                     for (const entry of pdfEntries) {
                         zip.append(Readable.from(entry.buffer), {

--- a/app/dashboard/payroll/download-payroll-zip-client.test.ts
+++ b/app/dashboard/payroll/download-payroll-zip-client.test.ts
@@ -1,0 +1,69 @@
+/** @vitest-environment jsdom */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { streamPayrollZipFromApi } from "@/app/dashboard/payroll/download-payroll-zip-client";
+
+describe("streamPayrollZipFromApi", () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it("parses NDJSON, reports progress events, and downloads a ZIP blob", async () => {
+        const progressEvents: string[] = [];
+        const lines = [
+            JSON.stringify({ type: "meta", n: 1 }),
+            JSON.stringify({
+                type: "progress",
+                i: 1,
+                n: 1,
+                workerName: "Bob",
+            }),
+            JSON.stringify({
+                type: "zip",
+                data: Buffer.from([0x50, 0x4b, 3, 4]).toString("base64"),
+            }),
+            JSON.stringify({
+                type: "done",
+                filename: "out.zip",
+                failed: 0,
+            }),
+        ];
+        const encoder = new TextEncoder();
+        const stream = new ReadableStream<Uint8Array>({
+            start(controller) {
+                for (const line of lines) {
+                    controller.enqueue(encoder.encode(`${line}\n`));
+                }
+                controller.close();
+            },
+        });
+
+        const mockClick = vi
+            .spyOn(HTMLAnchorElement.prototype, "click")
+            .mockImplementation(() => {});
+
+        const blobs: Blob[] = [];
+        vi.spyOn(URL, "createObjectURL").mockImplementation((blob) => {
+            blobs.push(blob as Blob);
+            return "blob:mock";
+        });
+        vi.spyOn(URL, "revokeObjectURL").mockImplementation(() => {});
+
+        global.fetch = vi.fn().mockResolvedValue(
+            new Response(stream, {
+                status: 200,
+                headers: { "Content-Type": "application/x-ndjson" },
+            }),
+        );
+
+        const result = await streamPayrollZipFromApi(["p1"], (evt) => {
+            progressEvents.push(evt.type);
+        });
+
+        expect(result).toEqual({ ok: true });
+        expect(progressEvents).toEqual(["meta", "progress", "done"]);
+        expect(blobs[0]?.type).toBe("application/zip");
+        expect(mockClick).toHaveBeenCalledTimes(1);
+    });
+});

--- a/app/dashboard/payroll/download-payroll-zip-client.ts
+++ b/app/dashboard/payroll/download-payroll-zip-client.ts
@@ -1,0 +1,246 @@
+"use client";
+
+export type PayrollZipStreamProgressEvent =
+    | { type: "meta"; n: number }
+    | { type: "progress"; i: number; n: number; workerName: string }
+    | { type: "done"; filename: string; failed: number }
+    | { type: "error"; message: string };
+
+export function computeZipEtaSec(args: {
+    n: number;
+    i: number;
+    elapsedSec: number;
+    recentDurationsSec: number[];
+}): number | undefined {
+    const { n, i, elapsedSec, recentDurationsSec } = args;
+    if (i < 2 || i >= n) return undefined;
+    let avgDelta: number;
+    if (recentDurationsSec.length >= 2) {
+        avgDelta =
+            recentDurationsSec.reduce((a, b) => a + b, 0) /
+            recentDurationsSec.length;
+    } else {
+        avgDelta = elapsedSec / i;
+    }
+    const eta = Math.round(avgDelta * (n - i));
+    if (!Number.isFinite(eta) || eta < 0) return undefined;
+    return eta;
+}
+
+function base64ToUint8Array(b64: string): Uint8Array {
+    const binary = atob(b64);
+    const len = binary.length;
+    const bytes = new Uint8Array(len);
+    for (let i = 0; i < len; i++) {
+        bytes[i] = binary.charCodeAt(i);
+    }
+    return bytes;
+}
+
+export async function streamPayrollZipFromApi(
+    payrollIds: string[],
+    onProgress: (event: PayrollZipStreamProgressEvent) => void,
+): Promise<{ ok: true } | { ok: false; error: string }> {
+    try {
+        const res = await fetch(
+            "/api/payroll/download-zip?progress=1",
+            {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    Accept: "application/x-ndjson",
+                },
+                body: JSON.stringify({ payrollIds }),
+            },
+        );
+
+        if (!res.ok) {
+            return {
+                ok: false,
+                error: `ZIP download failed (${res.status})`,
+            };
+        }
+
+        const reader = res.body?.getReader();
+        if (!reader) {
+            return { ok: false, error: "ZIP download failed (no body)" };
+        }
+
+        const decoder = new TextDecoder();
+        let buffer = "";
+        const zipChunks: BlobPart[] = [];
+
+        function handleNdjsonLine(line: string):
+            | { outcome: "continue" }
+            | { outcome: "success" }
+            | { outcome: "fail"; error: string } {
+            if (!line.trim()) return { outcome: "continue" };
+            let parsed: Record<string, unknown>;
+            try {
+                parsed = JSON.parse(line) as Record<string, unknown>;
+            } catch {
+                return { outcome: "fail", error: "Invalid progress stream" };
+            }
+
+            const t = parsed.type;
+            if (t === "zip" && typeof parsed.data === "string") {
+                zipChunks.push(base64ToUint8Array(parsed.data));
+                return { outcome: "continue" };
+            }
+
+            if (t === "meta") {
+                const n = parsed.n;
+                if (typeof n !== "number") {
+                    return { outcome: "fail", error: "Invalid progress stream" };
+                }
+                onProgress({ type: "meta", n });
+                return { outcome: "continue" };
+            }
+            if (t === "progress") {
+                const i = parsed.i;
+                const n = parsed.n;
+                const workerName = parsed.workerName;
+                if (
+                    typeof i !== "number" ||
+                    typeof n !== "number" ||
+                    typeof workerName !== "string"
+                ) {
+                    return { outcome: "fail", error: "Invalid progress stream" };
+                }
+                onProgress({
+                    type: "progress",
+                    i,
+                    n,
+                    workerName,
+                });
+                return { outcome: "continue" };
+            }
+            if (t === "done") {
+                const filename = parsed.filename;
+                const failed = parsed.failed;
+                if (
+                    typeof filename !== "string" ||
+                    typeof failed !== "number"
+                ) {
+                    return { outcome: "fail", error: "Invalid progress stream" };
+                }
+                onProgress({
+                    type: "done",
+                    filename,
+                    failed,
+                });
+                const blob = new Blob(zipChunks, {
+                    type: "application/zip",
+                });
+                const url = URL.createObjectURL(blob);
+                const a = document.createElement("a");
+                a.href = url;
+                a.download =
+                    filename ||
+                    `payrolls-${new Date().toISOString().slice(0, 10)}.zip`;
+                document.body.appendChild(a);
+                a.click();
+                a.remove();
+                URL.revokeObjectURL(url);
+                return { outcome: "success" };
+            }
+            if (t === "error") {
+                const message = parsed.message;
+                if (typeof message !== "string") {
+                    return { outcome: "fail", error: "Invalid progress stream" };
+                }
+                onProgress({ type: "error", message });
+                return { outcome: "fail", error: message };
+            }
+            return { outcome: "fail", error: "Invalid progress stream" };
+        }
+
+        while (true) {
+            const { done, value } = await reader.read();
+            if (done) {
+                buffer += decoder.decode();
+                break;
+            }
+            buffer += decoder.decode(value, { stream: true });
+            const lines = buffer.split("\n");
+            buffer = lines.pop() ?? "";
+
+            for (const line of lines) {
+                const r = handleNdjsonLine(line);
+                if (r.outcome === "success") return { ok: true };
+                if (r.outcome === "fail") return { ok: false, error: r.error };
+            }
+        }
+
+        if (buffer.trim()) {
+            const r = handleNdjsonLine(buffer);
+            if (r.outcome === "success") return { ok: true };
+            if (r.outcome === "fail") return { ok: false, error: r.error };
+        }
+
+        return { ok: false, error: "ZIP download ended unexpectedly" };
+    } catch (e) {
+        console.error(e);
+        return { ok: false, error: "Failed to download payroll PDFs" };
+    }
+}
+
+export function getDownloadFilenameFromContentDisposition(
+    header: string | null,
+): string | null {
+    if (!header) return null;
+
+    const star = header.match(/filename\*\s*=\s*([^;]+)/i);
+    if (star?.[1]) {
+        const raw = star[1].trim();
+        const unquoted = raw.replace(/^"(.*)"$/, "$1");
+        const parts = unquoted.split("''");
+        const encoded = parts.length === 2 ? parts[1] : unquoted;
+        try {
+            return decodeURIComponent(encoded);
+        } catch {
+            return encoded;
+        }
+    }
+
+    const plain = header.match(/filename\s*=\s*([^;]+)/i);
+    if (plain?.[1]) {
+        return plain[1].trim().replace(/^"(.*)"$/, "$1");
+    }
+
+    return null;
+}
+
+export async function downloadPayrollZipFromApi(payrollIds: string[]): Promise<
+    { ok: true } | { ok: false; error: string }
+> {
+    try {
+        const res = await fetch("/api/payroll/download-zip", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ payrollIds }),
+        });
+        if (!res.ok) {
+            return {
+                ok: false,
+                error: `ZIP download failed (${res.status})`,
+            };
+        }
+        const blob = await res.blob();
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement("a");
+        a.href = url;
+        a.download =
+            getDownloadFilenameFromContentDisposition(
+                res.headers.get("content-disposition"),
+            ) ?? `payrolls-${new Date().toISOString().slice(0, 10)}.zip`;
+        document.body.appendChild(a);
+        a.click();
+        a.remove();
+        URL.revokeObjectURL(url);
+        return { ok: true };
+    } catch (e) {
+        console.error(e);
+        return { ok: false, error: "Failed to download payroll PDFs" };
+    }
+}

--- a/app/dashboard/payroll/download-payrolls/download-payrolls-panel.tsx
+++ b/app/dashboard/payroll/download-payrolls/download-payrolls-panel.tsx
@@ -12,6 +12,15 @@ import {
     columns as baseColumns,
     type PayrollWithWorker,
 } from "@/app/dashboard/payroll/columns";
+import {
+    computeZipEtaSec,
+    streamPayrollZipFromApi,
+} from "@/app/dashboard/payroll/download-payroll-zip-client";
+import {
+    PayrollBulkZipProgressDialog,
+    type PayrollBulkZipProgressState,
+    type PayrollZipProgressPhase,
+} from "@/app/dashboard/payroll/payroll-bulk-zip-progress-dialog";
 import { fetchPayrollDownloadSelection } from "@/app/dashboard/payroll/read-api";
 
 const selectableColumns: ColumnDef<PayrollWithWorker>[] = [
@@ -21,44 +30,50 @@ const selectableColumns: ColumnDef<PayrollWithWorker>[] = [
     ...baseColumns,
 ];
 
-function getDownloadFilenameFromContentDisposition(
-    header: string | null,
-): string | null {
-    if (!header) return null;
-
-    const star = header.match(/filename\*\s*=\s*([^;]+)/i);
-    if (star?.[1]) {
-        const raw = star[1].trim();
-        const unquoted = raw.replace(/^"(.*)"$/, "$1");
-        const parts = unquoted.split("''");
-        const encoded = parts.length === 2 ? parts[1] : unquoted;
-        try {
-            return decodeURIComponent(encoded);
-        } catch {
-            return encoded;
-        }
-    }
-
-    const plain = header.match(/filename\s*=\s*([^;]+)/i);
-    if (plain?.[1]) {
-        return plain[1].trim().replace(/^"(.*)"$/, "$1");
-    }
-
-    return null;
-}
-
 export function DownloadPayrollsPanel() {
-    const [downloading, setDownloading] = React.useState(false);
     const [error, setError] = React.useState<string | null>(null);
     const [loading, setLoading] = React.useState(true);
     const [payrolls, setPayrolls] = React.useState<PayrollWithWorker[]>([]);
     const [rowSelection, setRowSelection] = React.useState<RowSelectionState>(
         {},
     );
+    const [zipDialogOpen, setZipDialogOpen] = React.useState(false);
+    const [zipPhase, setZipPhase] =
+        React.useState<PayrollZipProgressPhase>("generating");
+    const [zipError, setZipError] = React.useState<string | null>(null);
+    const [zipProgress, setZipProgress] =
+        React.useState<PayrollBulkZipProgressState | null>(null);
+    const [zipTick, setZipTick] = React.useState(0);
+    const zipStartedAtRef = React.useRef<number | null>(null);
+    const lastProgressAtRef = React.useRef<number | null>(null);
+    const durationsRef = React.useRef<number[]>([]);
 
     const selectedCount = Object.keys(rowSelection).filter(
         (k) => rowSelection[k],
     ).length;
+
+    const zipBusy = zipDialogOpen && zipError === null;
+
+    React.useEffect(() => {
+        if (!zipDialogOpen) return;
+        const id = window.setInterval(() => {
+            setZipTick((t) => t + 1);
+        }, 250);
+        return () => window.clearInterval(id);
+    }, [zipDialogOpen]);
+
+    const zipEtaSec = React.useMemo(() => {
+        if (!zipProgress) return undefined;
+        const elapsedSec = zipStartedAtRef.current
+            ? Math.floor((Date.now() - zipStartedAtRef.current) / 1000)
+            : 0;
+        return computeZipEtaSec({
+            n: zipProgress.n,
+            i: zipProgress.i,
+            elapsedSec,
+            recentDurationsSec: durationsRef.current,
+        });
+    }, [zipProgress, zipTick]);
 
     React.useEffect(() => {
         let cancelled = false;
@@ -85,6 +100,12 @@ export function DownloadPayrollsPanel() {
         };
     }, []);
 
+    function dismissZipDialog() {
+        setZipDialogOpen(false);
+        setZipError(null);
+        setZipProgress(null);
+    }
+
     async function handleDownload() {
         const selectedIds = Object.keys(rowSelection).filter(
             (k) => rowSelection[k],
@@ -92,40 +113,63 @@ export function DownloadPayrollsPanel() {
         if (selectedIds.length === 0) return;
 
         setError(null);
-        setDownloading(true);
+        setZipError(null);
+        setZipProgress(null);
+        zipStartedAtRef.current = Date.now();
+        lastProgressAtRef.current = null;
+        durationsRef.current = [];
+        setZipPhase("generating");
+        setZipDialogOpen(true);
 
-        try {
-            const res = await fetch("/api/payroll/download-zip", {
-                method: "POST",
-                headers: { "Content-Type": "application/json" },
-                body: JSON.stringify({ payrollIds: selectedIds }),
-            });
-            if (!res.ok) {
-                throw new Error(`ZIP download failed (${res.status})`);
-            }
-            const blob = await res.blob();
-            const url = URL.createObjectURL(blob);
-            const a = document.createElement("a");
-            a.href = url;
-            a.download =
-                getDownloadFilenameFromContentDisposition(
-                    res.headers.get("content-disposition"),
-                ) ?? `payrolls-${new Date().toISOString().slice(0, 10)}.zip`;
-            document.body.appendChild(a);
-            a.click();
-            a.remove();
-            URL.revokeObjectURL(url);
-        } catch (e) {
-            console.error(e);
-            setError("Failed to download payroll PDFs");
-        } finally {
-            setDownloading(false);
+        const result = await streamPayrollZipFromApi(
+            selectedIds,
+            (evt) => {
+                if (evt.type === "meta") {
+                    setZipProgress({ i: 0, n: evt.n });
+                    lastProgressAtRef.current = Date.now();
+                    durationsRef.current = [];
+                }
+                if (evt.type === "progress") {
+                    const now = Date.now();
+                    if (lastProgressAtRef.current !== null) {
+                        const dt =
+                            (now - lastProgressAtRef.current) / 1000;
+                        if (dt >= 0) {
+                            durationsRef.current = [
+                                ...durationsRef.current.slice(-4),
+                                dt,
+                            ];
+                        }
+                    }
+                    lastProgressAtRef.current = now;
+                    setZipProgress({
+                        i: evt.i,
+                        n: evt.n,
+                        currentName: evt.workerName,
+                    });
+                }
+            },
+        );
+        if (!result.ok) {
+            setZipError(result.error);
+            return;
         }
+
+        setZipDialogOpen(false);
+        setZipProgress(null);
     }
 
     return (
         <Card>
             <CardContent className="space-y-4 pt-6">
+                <PayrollBulkZipProgressDialog
+                    open={zipDialogOpen}
+                    phase={zipPhase}
+                    error={zipError}
+                    onDismiss={dismissZipDialog}
+                    progress={zipProgress}
+                    etaSec={zipEtaSec}
+                />
                 <p className="text-muted-foreground text-sm">
                     Select the payrolls you want to download as a ZIP of PDF
                     summaries.
@@ -151,9 +195,11 @@ export function DownloadPayrollsPanel() {
                 <div className="flex flex-wrap justify-end gap-2">
                     <Button
                         type="button"
-                        disabled={downloading || loading || selectedCount === 0}
+                        disabled={
+                            zipDialogOpen || loading || selectedCount === 0
+                        }
                         onClick={handleDownload}>
-                        {downloading
+                        {zipBusy
                             ? "Preparing ZIP..."
                             : `Download selected (${selectedCount})`}
                     </Button>

--- a/app/dashboard/payroll/payroll-bulk-zip-progress-dialog.test.tsx
+++ b/app/dashboard/payroll/payroll-bulk-zip-progress-dialog.test.tsx
@@ -1,0 +1,129 @@
+/** @vitest-environment jsdom */
+
+import React from "react";
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { PayrollBulkZipProgressDialog } from "@/app/dashboard/payroll/payroll-bulk-zip-progress-dialog";
+
+describe("PayrollBulkZipProgressDialog", () => {
+    afterEach(() => {
+        cleanup();
+    });
+
+    it("shows phase copy, indeterminate progress, and elapsed while in flight", () => {
+        render(
+            <PayrollBulkZipProgressDialog
+                open
+                phase="generating"
+                error={null}
+                onDismiss={vi.fn()}
+            />,
+        );
+
+        expect(
+            screen.getByRole("progressbar", { name: /in progress/i }),
+        ).toBeTruthy();
+        expect(
+            screen.getByText("Generating PDFs and building ZIP…"),
+        ).toBeTruthy();
+        expect(screen.getByText(/Elapsed:/)).toBeTruthy();
+    });
+
+    it("shows settling phase copy when phase is settling", () => {
+        render(
+            <PayrollBulkZipProgressDialog
+                open
+                phase="settling"
+                error={null}
+                onDismiss={vi.fn()}
+            />,
+        );
+
+        expect(screen.getByText("Settling payrolls…")).toBeTruthy();
+    });
+
+    it("calls onDismiss when the user activates Dismiss after an error", async () => {
+        const user = userEvent.setup();
+        const onDismiss = vi.fn();
+
+        render(
+            <PayrollBulkZipProgressDialog
+                open
+                phase="generating"
+                error="ZIP download failed (500)"
+                onDismiss={onDismiss}
+            />,
+        );
+
+        await user.click(screen.getByRole("button", { name: "Dismiss" }));
+        expect(onDismiss).toHaveBeenCalledTimes(1);
+    });
+
+    it("shows determinate copy, percent, and aria-valuenow when progress is set", () => {
+        render(
+            <PayrollBulkZipProgressDialog
+                open
+                phase="generating"
+                error={null}
+                onDismiss={vi.fn()}
+                progress={{ i: 5, n: 10, currentName: "Sam" }}
+                etaSec={120}
+            />,
+        );
+
+        expect(
+            screen.getByText("5 of 10 files finished processing"),
+        ).toBeTruthy();
+        expect(screen.getByText("50%")).toBeTruthy();
+        const bar = screen.getByRole("progressbar");
+        expect(bar.getAttribute("aria-valuenow")).toBe("50");
+        expect(screen.getByText("Current: Sam")).toBeTruthy();
+    });
+
+    it("shows Estimating when etaSec is undefined", () => {
+        render(
+            <PayrollBulkZipProgressDialog
+                open
+                phase="generating"
+                error={null}
+                onDismiss={vi.fn()}
+                progress={{ i: 1, n: 10 }}
+            />,
+        );
+
+        expect(screen.getByText("Estimating…")).toBeTruthy();
+    });
+
+    it("formats eta when etaSec is provided", () => {
+        render(
+            <PayrollBulkZipProgressDialog
+                open
+                phase="generating"
+                error={null}
+                onDismiss={vi.fn()}
+                progress={{ i: 3, n: 10 }}
+                etaSec={75}
+            />,
+        );
+
+        expect(screen.getByText("About 1:15 remaining")).toBeTruthy();
+    });
+
+    it("shows Finalizing ZIP and hides ETA when i equals n", () => {
+        render(
+            <PayrollBulkZipProgressDialog
+                open
+                phase="generating"
+                error={null}
+                onDismiss={vi.fn()}
+                progress={{ i: 10, n: 10 }}
+                etaSec={5}
+            />,
+        );
+
+        expect(screen.getByText("Finalizing ZIP…")).toBeTruthy();
+        expect(screen.queryByText(/About .* remaining/)).toBeNull();
+    });
+});

--- a/app/dashboard/payroll/payroll-bulk-zip-progress-dialog.tsx
+++ b/app/dashboard/payroll/payroll-bulk-zip-progress-dialog.tsx
@@ -1,0 +1,215 @@
+"use client";
+
+import * as React from "react";
+
+import { Button } from "@/components/ui/button";
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from "@/components/ui/dialog";
+import { Field, FieldLabel } from "@/components/ui/field";
+import { IndeterminateProgress } from "@/components/ui/indeterminate-progress";
+import { Progress } from "@/components/ui/progress";
+
+export type PayrollZipProgressPhase = "settling" | "generating";
+
+export function formatMmSs(totalSeconds: number): string {
+    if (totalSeconds >= 3600) {
+        const h = Math.floor(totalSeconds / 3600);
+        const m = Math.floor((totalSeconds % 3600) / 60);
+        const s = totalSeconds % 60;
+        return `${h}:${m.toString().padStart(2, "0")}:${s.toString().padStart(2, "0")}`;
+    }
+    const m = Math.floor(totalSeconds / 60);
+    const s = totalSeconds % 60;
+    return `${m}:${s.toString().padStart(2, "0")}`;
+}
+
+function formatElapsed(totalSeconds: number): string {
+    return formatMmSs(totalSeconds);
+}
+
+function phaseLabel(phase: PayrollZipProgressPhase): string {
+    return phase === "settling"
+        ? "Settling payrolls…"
+        : "Generating PDFs and building ZIP…";
+}
+
+export type PayrollBulkZipProgressState = {
+    i: number;
+    n: number;
+    currentName?: string;
+};
+
+export type PayrollBulkZipProgressDialogProps = {
+    open: boolean;
+    phase: PayrollZipProgressPhase;
+    error: string | null;
+    onDismiss: () => void;
+    progress?: PayrollBulkZipProgressState | null;
+    etaSec?: number;
+};
+
+export function PayrollBulkZipProgressDialog({
+    open,
+    phase,
+    error,
+    onDismiss,
+    progress,
+    etaSec,
+}: PayrollBulkZipProgressDialogProps) {
+    const [elapsedSec, setElapsedSec] = React.useState(0);
+    const inFlight = open && error === null;
+
+    React.useEffect(() => {
+        if (!open) {
+            setElapsedSec(0);
+            return;
+        }
+        const started = Date.now();
+        setElapsedSec(0);
+        const id = window.setInterval(() => {
+            setElapsedSec(Math.floor((Date.now() - started) / 1000));
+        }, 250);
+        return () => window.clearInterval(id);
+    }, [open]);
+
+    const showDeterminate =
+        progress != null &&
+        progress.n > 0 &&
+        phase === "generating";
+
+    const finalizing =
+        showDeterminate &&
+        progress != null &&
+        progress.i === progress.n &&
+        progress.n > 0;
+
+    const percent = showDeterminate
+        ? Math.min(
+              100,
+              Math.round(
+                  ((progress?.i ?? 0) / (progress?.n ?? 1)) * 100,
+              ),
+          )
+        : 0;
+
+    return (
+        <Dialog
+            open={open}
+            onOpenChange={(next) => {
+                if (!next && error !== null) {
+                    onDismiss();
+                }
+            }}>
+            <DialogContent
+                showCloseButton={false}
+                onPointerDownOutside={(e) => {
+                    if (inFlight) e.preventDefault();
+                }}
+                onEscapeKeyDown={(e) => {
+                    if (inFlight) e.preventDefault();
+                }}
+                className="sm:max-w-md">
+                <DialogHeader>
+                    <DialogTitle>
+                        {error ? "Something went wrong" : "Preparing download"}
+                    </DialogTitle>
+                    {error ? (
+                        <DialogDescription className="text-destructive">
+                            {error}
+                        </DialogDescription>
+                    ) : (
+                        <DialogDescription className="sr-only">
+                            {phaseLabel(phase)} Elapsed{" "}
+                            {formatElapsed(elapsedSec)}.
+                        </DialogDescription>
+                    )}
+                </DialogHeader>
+                {!error ? (
+                    <div
+                        className="space-y-4"
+                        aria-live="polite"
+                        aria-atomic="true">
+                        {showDeterminate ? (
+                            <>
+                                {finalizing ? (
+                                    <>
+                                        <p className="text-foreground text-sm">
+                                            Finalizing ZIP…
+                                        </p>
+                                        <Progress
+                                            value={100}
+                                            aria-valuenow={100}
+                                            aria-valuemin={0}
+                                            aria-valuemax={100}
+                                        />
+                                    </>
+                                ) : (
+                                    <Field>
+                                        <FieldLabel className="flex w-full items-center justify-between">
+                                            <span>{`${progress?.i ?? 0} of ${progress?.n ?? 0} files finished processing`}</span>
+                                            <span className="text-muted-foreground tabular-nums">
+                                                {percent}%
+                                            </span>
+                                        </FieldLabel>
+                                        <Progress
+                                            value={percent}
+                                            aria-valuenow={percent}
+                                            aria-valuemin={0}
+                                            aria-valuemax={100}
+                                        />
+                                        {progress?.currentName ? (
+                                            <p className="text-muted-foreground truncate text-xs">
+                                                Current: {progress.currentName}
+                                            </p>
+                                        ) : null}
+                                    </Field>
+                                )}
+                                <div className="text-muted-foreground flex items-center justify-between text-xs tabular-nums">
+                                    <span>
+                                        Elapsed: {formatElapsed(elapsedSec)}
+                                    </span>
+                                    {finalizing ? null : etaSec !==
+                                      undefined ? (
+                                        <span aria-live="polite">
+                                            About {formatMmSs(etaSec)} remaining
+                                        </span>
+                                    ) : (
+                                        <span className="opacity-60">
+                                            Estimating…
+                                        </span>
+                                    )}
+                                </div>
+                            </>
+                        ) : (
+                            <>
+                                <p className="text-foreground text-sm">
+                                    {phaseLabel(phase)}
+                                </p>
+                                <IndeterminateProgress />
+                                <p className="text-muted-foreground text-xs">
+                                    Elapsed: {formatElapsed(elapsedSec)}
+                                </p>
+                                <p className="text-muted-foreground text-xs">
+                                    Larger selections can take several minutes.
+                                </p>
+                            </>
+                        )}
+                    </div>
+                ) : null}
+                {error ? (
+                    <DialogFooter>
+                        <Button type="button" onClick={onDismiss}>
+                            Dismiss
+                        </Button>
+                    </DialogFooter>
+                ) : null}
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/app/dashboard/payroll/read-api.ts
+++ b/app/dashboard/payroll/read-api.ts
@@ -23,7 +23,27 @@ async function readPayrollApi<T>(path: string): Promise<T> {
         cache: "no-store",
     });
 
-    const body = (await response.json()) as ApiReadSuccess<T> | ApiReadFailure;
+    const raw = await response.text();
+    const trimmed = raw.trim();
+
+    if (!trimmed) {
+        throw new Error(
+            response.ok
+                ? "Empty response from server"
+                : `Request failed (${response.status})`,
+        );
+    }
+
+    let body: ApiReadSuccess<T> | ApiReadFailure;
+    try {
+        body = JSON.parse(trimmed) as ApiReadSuccess<T> | ApiReadFailure;
+    } catch {
+        throw new Error(
+            response.ok
+                ? "Invalid response from server"
+                : `Request failed (${response.status})`,
+        );
+    }
 
     if (!response.ok || !body.ok) {
         throw new Error(body.ok ? "Request failed" : body.error.message);

--- a/app/dashboard/payroll/selection-dialogs.test.tsx
+++ b/app/dashboard/payroll/selection-dialogs.test.tsx
@@ -2,7 +2,8 @@
 
 import React from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 
 const mocks = vi.hoisted(() => ({
     push: vi.fn(),
@@ -10,6 +11,7 @@ const mocks = vi.hoisted(() => ({
     fetchSettlementCandidates: vi.fn(),
     fetchPayrollDownloadSelection: vi.fn(),
     settleDraftPayrolls: vi.fn(),
+    streamPayrollZipFromApi: vi.fn(),
 }));
 
 vi.mock("next/navigation", () => ({
@@ -31,28 +33,57 @@ vi.mock("@/app/dashboard/payroll/command-api", () => ({
         mocks.settleDraftPayrolls(...args),
 }));
 
+vi.mock("@/app/dashboard/payroll/download-payroll-zip-client", () => ({
+    streamPayrollZipFromApi: (...args: unknown[]) =>
+        mocks.streamPayrollZipFromApi(...args),
+    computeZipEtaSec: () => undefined,
+}));
+
 vi.mock("@/components/data-table/data-table", () => ({
     DataTable: ({
         data,
         isLoading,
+        enableRowSelection,
+        onRowSelectionChange,
+        getRowId,
     }: {
-        data: Array<{ workerName: string }>;
+        data: Array<{ workerName: string; id: string }>;
         isLoading?: boolean;
+        enableRowSelection?: boolean;
+        onRowSelectionChange?: (next: Record<string, boolean>) => void;
+        getRowId?: (row: { id: string }) => string;
     }) => (
         <div data-testid="mock-data-table">
             {isLoading ? (
                 <div data-testid="mock-datatable-loading">Loading table</div>
             ) : (
-                data.map((row) => (
-                    <div key={row.workerName}>{row.workerName}</div>
-                ))
+                <>
+                    {enableRowSelection && onRowSelectionChange && getRowId ? (
+                        <button
+                            type="button"
+                            data-testid="mock-select-first-row"
+                            onClick={() => {
+                                const first = data[0];
+                                if (first) {
+                                    onRowSelectionChange({
+                                        [getRowId(first)]: true,
+                                    });
+                                }
+                            }}>
+                            Select first row (test)
+                        </button>
+                    ) : null}
+                    {data.map((row) => (
+                        <div key={row.workerName}>{row.workerName}</div>
+                    ))}
+                </>
             )}
         </div>
     ),
 }));
 
-import { SettleDraftPayrollsPanel } from "@/app/dashboard/payroll/settle-draft-payrolls-panel";
-import { DownloadPayrollsPanel } from "@/app/dashboard/payroll/download-payrolls-panel";
+import { SettleDraftPayrollsPanel } from "@/app/dashboard/payroll/settle-drafts/settle-draft-payrolls-panel";
+import { DownloadPayrollsPanel } from "@/app/dashboard/payroll/download-payrolls/download-payrolls-panel";
 
 function createDeferred<T>() {
     let resolve!: (value: T | PromiseLike<T>) => void;
@@ -86,7 +117,12 @@ describe("Payroll selection panels", () => {
 
     beforeEach(() => {
         vi.clearAllMocks();
-        mocks.settleDraftPayrolls.mockResolvedValue({ success: true });
+        mocks.settleDraftPayrolls.mockResolvedValue({
+            success: true,
+            settled: 1,
+            settledPayrollIds: ["payroll-1"],
+        });
+        mocks.streamPayrollZipFromApi.mockResolvedValue({ ok: true });
     });
 
     it("lazy-loads settlement candidates and preserves the loading state", async () => {
@@ -127,5 +163,128 @@ describe("Payroll selection panels", () => {
         expect(
             screen.getByRole("button", { name: "Download selected (0)" }),
         ).toBeTruthy();
+    });
+
+    it("opens the ZIP progress dialog when downloading a selection", async () => {
+        const user = userEvent.setup();
+        let resolveZip!: (value: { ok: true }) => void;
+        const zipPromise = new Promise<{ ok: true }>((resolve) => {
+            resolveZip = resolve;
+        });
+        mocks.streamPayrollZipFromApi.mockImplementationOnce(() => zipPromise);
+        mocks.fetchPayrollDownloadSelection.mockResolvedValue([payrollRow]);
+
+        render(<DownloadPayrollsPanel />);
+
+        expect(await screen.findByText("Alice")).toBeTruthy();
+        await user.click(screen.getByTestId("mock-select-first-row"));
+
+        await user.click(
+            screen.getByRole("button", { name: "Download selected (1)" }),
+        );
+
+        expect(
+            await screen.findByRole("dialog", { name: "Preparing download" }),
+        ).toBeTruthy();
+        expect(
+            screen.getByText("Generating PDFs and building ZIP…"),
+        ).toBeTruthy();
+        resolveZip({ ok: true });
+        await waitFor(() => {
+            expect(
+                screen.queryByRole("dialog", { name: "Preparing download" }),
+            ).toBeNull();
+        });
+    });
+
+    it("shows settling then generating in the dialog when settling drafts", async () => {
+        const user = userEvent.setup();
+        let resolveSettle!: (value: unknown) => void;
+        const settlePromise = new Promise((resolve) => {
+            resolveSettle = resolve;
+        });
+        let resolveZip!: (value: { ok: true }) => void;
+        const zipPromise = new Promise<{ ok: true }>((resolve) => {
+            resolveZip = resolve;
+        });
+        mocks.settleDraftPayrolls.mockImplementationOnce(() => settlePromise);
+        mocks.streamPayrollZipFromApi.mockImplementationOnce(() => zipPromise);
+        mocks.fetchSettlementCandidates.mockResolvedValue([payrollRow]);
+
+        render(<SettleDraftPayrollsPanel />);
+
+        expect(await screen.findByText("Alice")).toBeTruthy();
+        const clickDone = user.click(
+            screen.getByRole("button", { name: "Settle selected (1)" }),
+        );
+
+        expect(
+            await screen.findByText("Settling payrolls…"),
+        ).toBeTruthy();
+
+        resolveSettle({
+            success: true,
+            settled: 1,
+            settledPayrollIds: ["payroll-1"],
+        });
+
+        await waitFor(() => {
+            expect(
+                screen.getByText("Generating PDFs and building ZIP…"),
+            ).toBeTruthy();
+        });
+
+        resolveZip({ ok: true });
+        await clickDone;
+        await waitFor(() => {
+            expect(
+                screen.queryByRole("dialog", { name: "Preparing download" }),
+            ).toBeNull();
+        });
+    });
+
+    it("shows determinate ZIP progress after stream progress events", async () => {
+        const user = userEvent.setup();
+        mocks.streamPayrollZipFromApi.mockImplementationOnce(
+            (
+                _ids: string[],
+                onProgress: (e: {
+                    type: string;
+                    n?: number;
+                    i?: number;
+                    workerName?: string;
+                }) => void,
+            ) =>
+                new Promise<{ ok: true }>((resolve) => {
+                    setTimeout(() => {
+                        onProgress({ type: "meta", n: 2 });
+                        setTimeout(() => {
+                            onProgress({
+                                type: "progress",
+                                i: 1,
+                                n: 2,
+                                workerName: "Alice",
+                            });
+                            setTimeout(() => resolve({ ok: true }), 0);
+                        }, 0);
+                    }, 0);
+                }),
+        );
+        mocks.fetchPayrollDownloadSelection.mockResolvedValue([payrollRow]);
+
+        render(<DownloadPayrollsPanel />);
+
+        expect(await screen.findByText("Alice")).toBeTruthy();
+        await user.click(screen.getByTestId("mock-select-first-row"));
+
+        await user.click(
+            screen.getByRole("button", { name: "Download selected (1)" }),
+        );
+
+        await waitFor(() => {
+            expect(
+                screen.getByText("1 of 2 files finished processing"),
+            ).toBeTruthy();
+        });
     });
 });

--- a/app/dashboard/payroll/settle-drafts/settle-draft-payrolls-panel.tsx
+++ b/app/dashboard/payroll/settle-drafts/settle-draft-payrolls-panel.tsx
@@ -16,6 +16,15 @@ import {
 import { createRowSelectionColumn } from "@/components/data-table/column-builders";
 import { DataTable } from "@/components/data-table/data-table";
 import { settleDraftPayrolls } from "@/app/dashboard/payroll/command-api";
+import {
+    computeZipEtaSec,
+    streamPayrollZipFromApi,
+} from "@/app/dashboard/payroll/download-payroll-zip-client";
+import {
+    PayrollBulkZipProgressDialog,
+    type PayrollBulkZipProgressState,
+    type PayrollZipProgressPhase,
+} from "@/app/dashboard/payroll/payroll-bulk-zip-progress-dialog";
 import { fetchSettlementCandidates } from "@/app/dashboard/payroll/read-api";
 import {
     columns as baseColumns,
@@ -31,14 +40,22 @@ const selectableColumns: ColumnDef<PayrollWithWorker>[] = [
 
 export function SettleDraftPayrollsPanel() {
     const router = useRouter();
-    const [pending, setPending] = React.useState(false);
-    const [downloadingZip, setDownloadingZip] = React.useState(false);
     const [error, setError] = React.useState<string | null>(null);
     const [loadingDrafts, setLoadingDrafts] = React.useState(true);
     const [drafts, setDrafts] = React.useState<PayrollWithWorker[]>([]);
     const [rowSelection, setRowSelection] = React.useState<RowSelectionState>(
         {},
     );
+    const [zipDialogOpen, setZipDialogOpen] = React.useState(false);
+    const [zipPhase, setZipPhase] =
+        React.useState<PayrollZipProgressPhase>("settling");
+    const [zipError, setZipError] = React.useState<string | null>(null);
+    const [zipProgress, setZipProgress] =
+        React.useState<PayrollBulkZipProgressState | null>(null);
+    const [zipTick, setZipTick] = React.useState(0);
+    const zipStartedAtRef = React.useRef<number | null>(null);
+    const lastProgressAtRef = React.useRef<number | null>(null);
+    const durationsRef = React.useRef<number[]>([]);
 
     const draftCount = drafts.length;
     const selectedCount = Object.keys(rowSelection).filter(
@@ -48,6 +65,29 @@ export function SettleDraftPayrollsPanel() {
     const resetUi = React.useCallback(() => {
         setError(null);
     }, []);
+
+    const zipBusy = zipDialogOpen && zipError === null;
+
+    React.useEffect(() => {
+        if (!zipDialogOpen) return;
+        const id = window.setInterval(() => {
+            setZipTick((t) => t + 1);
+        }, 250);
+        return () => window.clearInterval(id);
+    }, [zipDialogOpen]);
+
+    const zipEtaSec = React.useMemo(() => {
+        if (!zipProgress) return undefined;
+        const elapsedSec = zipStartedAtRef.current
+            ? Math.floor((Date.now() - zipStartedAtRef.current) / 1000)
+            : 0;
+        return computeZipEtaSec({
+            n: zipProgress.n,
+            i: zipProgress.i,
+            elapsedSec,
+            recentDurationsSec: durationsRef.current,
+        });
+    }, [zipProgress, zipTick]);
 
     React.useEffect(() => {
         let cancelled = false;
@@ -77,30 +117,10 @@ export function SettleDraftPayrollsPanel() {
         };
     }, []);
 
-    function getDownloadFilenameFromContentDisposition(
-        header: string | null,
-    ): string | null {
-        if (!header) return null;
-
-        const star = header.match(/filename\*\s*=\s*([^;]+)/i);
-        if (star?.[1]) {
-            const raw = star[1].trim();
-            const unquoted = raw.replace(/^"(.*)"$/, "$1");
-            const parts = unquoted.split("''");
-            const encoded = parts.length === 2 ? parts[1] : unquoted;
-            try {
-                return decodeURIComponent(encoded);
-            } catch {
-                return encoded;
-            }
-        }
-
-        const plain = header.match(/filename\s*=\s*([^;]+)/i);
-        if (plain?.[1]) {
-            return plain[1].trim().replace(/^"(.*)"$/, "$1");
-        }
-
-        return null;
+    function dismissZipDialog() {
+        setZipDialogOpen(false);
+        setZipError(null);
+        setZipProgress(null);
     }
 
     async function handleSettleSelected() {
@@ -110,57 +130,79 @@ export function SettleDraftPayrollsPanel() {
         if (selectedIds.length === 0) return;
 
         setError(null);
-        setPending(true);
+        setZipError(null);
+        setZipProgress(null);
+        setZipPhase("settling");
+        setZipDialogOpen(true);
 
         const result = await settleDraftPayrolls(selectedIds);
 
-        setPending(false);
         if ("error" in result) {
-            setError(result.error);
+            setZipError(result.error);
             return;
         }
 
         const ids = result.settledPayrollIds;
-        if (ids.length > 0) {
-            setDownloadingZip(true);
-            try {
-                const res = await fetch("/api/payroll/download-zip", {
-                    method: "POST",
-                    headers: { "Content-Type": "application/json" },
-                    body: JSON.stringify({ payrollIds: ids }),
-                });
-                if (!res.ok) {
-                    throw new Error(`ZIP download failed (${res.status})`);
-                }
-                const blob = await res.blob();
-                const url = URL.createObjectURL(blob);
-                const a = document.createElement("a");
-                a.href = url;
-                a.download =
-                    getDownloadFilenameFromContentDisposition(
-                        res.headers.get("content-disposition"),
-                    ) ??
-                    `payrolls-${new Date().toISOString().slice(0, 10)}.zip`;
-                document.body.appendChild(a);
-                a.click();
-                a.remove();
-                URL.revokeObjectURL(url);
-            } catch (e) {
-                console.error(e);
-                setError("Failed to download payroll PDFs ZIP");
-                setDownloadingZip(false);
-                return;
-            } finally {
-                setDownloadingZip(false);
-            }
+        if (ids.length === 0) {
+            setZipDialogOpen(false);
+            setZipProgress(null);
+            resetUi();
+            router.refresh();
+            return;
         }
 
+        setZipPhase("generating");
+        zipStartedAtRef.current = Date.now();
+        lastProgressAtRef.current = null;
+        durationsRef.current = [];
+        setZipProgress(null);
+
+        const zipResult = await streamPayrollZipFromApi(ids, (evt) => {
+            if (evt.type === "meta") {
+                setZipProgress({ i: 0, n: evt.n });
+                lastProgressAtRef.current = Date.now();
+                durationsRef.current = [];
+            }
+            if (evt.type === "progress") {
+                const now = Date.now();
+                if (lastProgressAtRef.current !== null) {
+                    const dt = (now - lastProgressAtRef.current) / 1000;
+                    if (dt >= 0) {
+                        durationsRef.current = [
+                            ...durationsRef.current.slice(-4),
+                            dt,
+                        ];
+                    }
+                }
+                lastProgressAtRef.current = now;
+                setZipProgress({
+                    i: evt.i,
+                    n: evt.n,
+                    currentName: evt.workerName,
+                });
+            }
+        });
+        if (!zipResult.ok) {
+            setZipError(zipResult.error);
+            return;
+        }
+
+        setZipDialogOpen(false);
+        setZipProgress(null);
         resetUi();
         router.refresh();
     }
 
     return (
         <Card>
+            <PayrollBulkZipProgressDialog
+                open={zipDialogOpen}
+                phase={zipPhase}
+                error={zipError}
+                onDismiss={dismissZipDialog}
+                progress={zipProgress}
+                etaSec={zipEtaSec}
+            />
             <CardHeader>
                 <CardTitle>Confirm settlement</CardTitle>
                 <CardDescription>
@@ -192,17 +234,16 @@ export function SettleDraftPayrollsPanel() {
                         type="button"
                         variant="destructive"
                         disabled={
-                            pending ||
-                            downloadingZip ||
+                            zipDialogOpen ||
                             loadingDrafts ||
                             selectedCount === 0
                         }
                         onClick={handleSettleSelected}>
-                        {pending
-                            ? "Settling..."
-                            : downloadingZip
-                              ? "Preparing ZIP..."
-                              : `Settle selected (${selectedCount})`}
+                        {zipBusy
+                            ? zipPhase === "settling"
+                                ? "Settling..."
+                                : "Preparing ZIP..."
+                            : `Settle selected (${selectedCount})`}
                     </Button>
                 </div>
             </CardContent>

--- a/app/globals.css
+++ b/app/globals.css
@@ -45,6 +45,17 @@
     --radius-2xl: calc(var(--radius) + 8px);
     --radius-3xl: calc(var(--radius) + 12px);
     --radius-4xl: calc(var(--radius) + 16px);
+    --animate-payroll-zip-indeterminate: payroll-zip-indeterminate 1.2s ease-in-out
+        infinite;
+}
+
+@keyframes payroll-zip-indeterminate {
+    0% {
+        transform: translateX(-100%);
+    }
+    100% {
+        transform: translateX(350%);
+    }
 }
 
 :root {

--- a/components/ui/indeterminate-progress.tsx
+++ b/components/ui/indeterminate-progress.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+export function IndeterminateProgress({
+    className,
+    ...props
+}: React.ComponentProps<"div">) {
+    return (
+        <div
+            role="progressbar"
+            aria-busy="true"
+            aria-label="In progress"
+            aria-valuetext="In progress"
+            className={cn(
+                "relative h-2 w-full overflow-hidden rounded-full bg-primary/20",
+                className,
+            )}
+            {...props}>
+            <div
+                className="bg-primary absolute h-full w-2/5 rounded-full animate-payroll-zip-indeterminate"
+                aria-hidden
+            />
+        </div>
+    );
+}

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -34,8 +34,8 @@ enabled = false
 
 [studio]
 enabled = true
-api_url = "env(SUPABASE_STUDIO_URL)"
-port = "env(SUPABASE_STUDIO_URL)"
+api_url = "env(LOCAL_SUPABASE_STUDIO_URL)"
+port = "env(LOCAL_SUPABASE_STUDIO_URL)"
 openai_api_key = "env(OPENAI_API_KEY)"
 
 [inbucket]


### PR DESCRIPTION
Adds client-side payroll bulk ZIP download with a progress dialog and indeterminate progress indicator. Updates the download-zip API route for streaming/chunked behavior, wires download and settle-draft panels, and extends tests.

**Includes:** `download-payroll-zip-client`, `payroll-bulk-zip-progress-dialog`, `indeterminate-progress`, API and read-api updates, `globals.css` animation, minor `supabase/config.toml` tweak.

Made with [Cursor](https://cursor.com)