### PR TITLE
Userflow: February AttendRecord import + staged timesheet pipeline

### DIFF
--- a/playwright.userflow.config.ts
+++ b/playwright.userflow.config.ts
@@ -30,10 +30,37 @@ export default defineConfig({
     },
     projects: [
         {
-            name: "chromium",
+            name: "worker-new",
             use: {
                 ...devices["Desktop Chrome"],
             },
+            testMatch: ["workers/01-*.spec.ts"],
+        },
+        {
+            name: "worker-edit",
+            use: {
+                ...devices["Desktop Chrome"],
+            },
+            testMatch: ["workers/**/*.spec.ts"],
+            testIgnore: ["workers/01-*.spec.ts"],
+            dependencies: ["worker-new"],
+        },
+        {
+            name: "timesheet-march",
+            use: {
+                ...devices["Desktop Chrome"],
+            },
+            testMatch: ["timesheets/01-*.spec.ts"],
+            dependencies: ["worker-edit"],
+        },
+        {
+            name: "timesheet-followups",
+            use: {
+                ...devices["Desktop Chrome"],
+            },
+            testMatch: ["timesheets/**/*.spec.ts"],
+            testIgnore: ["timesheets/01-*.spec.ts"],
+            dependencies: ["timesheet-march"],
         },
     ],
 });

--- a/test/userflow/timesheets/02-timesheet-february-import-userflow.spec.ts
+++ b/test/userflow/timesheets/02-timesheet-february-import-userflow.spec.ts
@@ -1,0 +1,37 @@
+import { expect, test } from "@playwright/test";
+
+import { assertOpenDashboardAccess } from "../../e2e/worker-test-helpers";
+import { signInToUserflowSession } from "../workers/worker-userflow-helpers";
+import {
+    createFebruary2026AttendRecordArtifactsFromLatestWorkerHandoff,
+} from "./february-attendrecord-artifact-helpers";
+import {
+    assertFebruaryImportPreviewBeforeRemapping,
+    remapFebruaryImportPreviewWorkers,
+    submitFebruaryAttendRecordImport,
+    uploadFebruaryAttendRecordWorkbook,
+    verifyFebruaryImportedRowsInAllTimesheetsUi,
+} from "./timesheet-import-userflow-playwright-helpers";
+
+test.describe("Timesheet userflow", () => {
+    test("imports the deterministic February 2026 AttendRecord workbook after the March smoke path", async ({
+        page,
+    }) => {
+        test.setTimeout(5 * 60_000);
+
+        const artifact =
+            await createFebruary2026AttendRecordArtifactsFromLatestWorkerHandoff();
+
+        expect(artifact.expectedRowCount).toBe(102);
+        expect(artifact.workers).toHaveLength(4);
+
+        await signInToUserflowSession(page, "/dashboard/timesheet/import");
+        await assertOpenDashboardAccess(page);
+
+        await uploadFebruaryAttendRecordWorkbook(page, artifact);
+        await assertFebruaryImportPreviewBeforeRemapping(page, artifact);
+        await remapFebruaryImportPreviewWorkers(page, artifact);
+        await submitFebruaryAttendRecordImport(page, artifact);
+        await verifyFebruaryImportedRowsInAllTimesheetsUi(page, artifact);
+    });
+});

--- a/test/userflow/timesheets/february-attendrecord-artifact-helpers.test.ts
+++ b/test/userflow/timesheets/february-attendrecord-artifact-helpers.test.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 
 import { describe, expect, it } from "vitest";
+import * as XLSX from "xlsx";
 
 import {
     FEBRUARY_2026_MONTH,
@@ -73,6 +74,8 @@ describe("february-attendrecord-artifact-helpers", () => {
                 (entry) => entry.dateIn === "2026-02-04",
             ),
         ).toBe(false);
+
+        expectMissingDateCoverage(artifact);
     });
 
     it("writes a real .xls workbook and JSON handoff that round-trip through the AttendRecord parser", async () => {
@@ -136,6 +139,75 @@ describe("february-attendrecord-artifact-helpers", () => {
             await rm(tempDir, { recursive: true, force: true });
         }
     });
+
+    it("preserves the raw AttendRecord RecordTable sheet structure and blank missing-date cells", async () => {
+        const tempDir = await mkdtemp(
+            path.join(os.tmpdir(), "february-attendrecord-workbook-"),
+        );
+        const workbookPath = path.join(tempDir, "generated-attendrecord.xls");
+        const handoffPath = path.join(tempDir, "attendrecord-handoff.json");
+        const artifact = withWorkbookPath(
+            buildFebruary2026AttendRecordArtifact(buildWorkerHandoff()),
+            workbookPath,
+        );
+
+        try {
+            await writeFebruary2026AttendRecordArtifacts(artifact, handoffPath);
+
+            const workbook = XLSX.readFile(workbookPath);
+            const recordTableSheet = workbook.Sheets.RecordTable;
+
+            expect(recordTableSheet).toBeDefined();
+
+            const rows = XLSX.utils.sheet_to_json(recordTableSheet!, {
+                header: 1,
+                blankrows: true,
+                raw: false,
+                defval: "",
+            }) as string[][];
+
+            expect(rows[0]?.[0]).toBe("Attendance date:01/02/2026 ~28/02/2026");
+            expect(rows[1]?.[0]).toBe("Tabling date:28/02/2026 23:59:59");
+
+            for (const [index, worker] of artifact.workers.entries()) {
+                const rowOffset = 2 + index * 4;
+                const workerRow = rows[rowOffset];
+                const headerRow = rows[rowOffset + 1];
+                const valuesRow = rows[rowOffset + 2];
+                const spacerRow = rows[rowOffset + 3];
+
+                expect(workerRow?.slice(0, 5)).toEqual([
+                    "UserID:",
+                    "",
+                    worker.aliasUserId,
+                    "Name:",
+                    worker.workerAlias,
+                ]);
+                expect(headerRow).toEqual([
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    ...Array.from({ length: 28 }, (_, dayIndex) =>
+                        String(dayIndex + 1),
+                    ),
+                ]);
+                expect(
+                    spacerRow === undefined ||
+                        spacerRow.every((cell) => cell === ""),
+                ).toBe(true);
+
+                for (const missingDate of worker.missingDates) {
+                    const dayIndex = Number.parseInt(missingDate.slice(-2), 10) - 1;
+
+                    expect(valuesRow?.[5 + dayIndex]).toBe("");
+                }
+            }
+        } finally {
+            await rm(tempDir, { recursive: true, force: true });
+        }
+    });
 });
 
 function buildWorkerHandoff() {
@@ -179,4 +251,29 @@ function toIsoDate(displayDate: string): string {
     const [day, month, year] = displayDate.split("/");
 
     return `${year}-${month}-${day}`;
+}
+
+function expectMissingDateCoverage(
+    artifact: FebruaryAttendRecordArtifactHandoff,
+): void {
+    expect(
+        artifact.workers.find(
+            (worker) => worker.permutationKey === "full-time-foreign-paynow",
+        )?.missingDates,
+    ).toHaveLength(2);
+    expect(
+        artifact.workers.find(
+            (worker) => worker.permutationKey === "part-time-foreign-cash",
+        )?.missingDates,
+    ).toHaveLength(3);
+    expect(
+        artifact.workers.find(
+            (worker) => worker.permutationKey === "full-time-local-bank-transfer",
+        )?.missingDates,
+    ).toHaveLength(4);
+    expect(
+        artifact.workers.find(
+            (worker) => worker.permutationKey === "part-time-local-paynow",
+        )?.missingDates,
+    ).toHaveLength(1);
 }

--- a/test/userflow/timesheets/february-attendrecord-artifact-helpers.test.ts
+++ b/test/userflow/timesheets/february-attendrecord-artifact-helpers.test.ts
@@ -1,0 +1,182 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import {
+    FEBRUARY_2026_MONTH,
+    buildFebruary2026AttendRecordArtifact,
+    parseGeneratedAttendRecordWorkbook,
+    writeFebruary2026AttendRecordArtifacts,
+    type FebruaryAttendRecordArtifactHandoff,
+} from "./february-attendrecord-artifact-helpers";
+import { WORKER_USERFLOW_PERMUTATIONS } from "../workers/worker-userflow-helpers";
+
+describe("february-attendrecord-artifact-helpers", () => {
+    it("builds a deterministic February 2026 AttendRecord dataset from edited worker handoff state", () => {
+        const artifact = buildFebruary2026AttendRecordArtifact(buildWorkerHandoff());
+
+        expect(artifact.month).toBe(FEBRUARY_2026_MONTH);
+        expect(artifact.runId).toBe("run-123");
+        expect(artifact.expectedRowCount).toBe(102);
+        expect(artifact.workers.map((worker) => worker.permutationKey)).toEqual(
+            WORKER_USERFLOW_PERMUTATIONS.map((permutation) => permutation.key),
+        );
+        expect(artifact.workers.map((worker) => worker.workerName)).toEqual([
+            "Worker 1 Edited",
+            "Worker 2 Edited",
+            "Worker 3 Edited",
+            "Worker 4 Edited",
+        ]);
+        expect(artifact.workers.map((worker) => worker.workerAlias)).toEqual([
+            "AttendRecord 1 Worker 1",
+            "AttendRecord 2 Worker 2",
+            "AttendRecord 3 Worker 3",
+            "AttendRecord 4 Worker 4",
+        ]);
+        expect(artifact.workers.map((worker) => worker.aliasUserId)).toEqual([
+            "ATT-RUN123-01",
+            "ATT-RUN123-02",
+            "ATT-RUN123-03",
+            "ATT-RUN123-04",
+        ]);
+
+        expect(artifact.workers.map((worker) => worker.totalImportedRows)).toEqual([
+            24, 26, 25, 27,
+        ]);
+        expect(artifact.workers.map((worker) => worker.totalHours)).toEqual([
+            264, 260, 262.5, 256.5,
+        ]);
+        expect(artifact.workers.map((worker) => worker.missingDates)).toEqual([
+            ["2026-02-04", "2026-02-11", "2026-02-18", "2026-02-25"],
+            ["2026-02-08", "2026-02-22"],
+            ["2026-02-03", "2026-02-10", "2026-02-17"],
+            ["2026-02-14"],
+        ]);
+
+        for (const worker of artifact.workers) {
+            expect(worker.totalHours).toBeGreaterThanOrEqual(255);
+            expect(worker.totalHours).toBeLessThanOrEqual(265);
+            expect(worker.workerAlias).not.toBe(worker.workerName);
+            expect(worker.entries).toHaveLength(worker.totalImportedRows);
+            expect(worker.entries.every((entry) => entry.workerAlias === worker.workerAlias)).toBe(true);
+            expect(worker.entries.every((entry) => entry.aliasUserId === worker.aliasUserId)).toBe(true);
+            expect(worker.entries.every((entry) => entry.workerName === worker.workerName)).toBe(true);
+        }
+
+        expect(artifact.workers[0]?.entries[0]?.rowSignature).toBe(
+            "Worker 1 Edited | 01/02/2026 | 01/02/2026 | 08:00 | 19:00 | 11.00",
+        );
+        expect(
+            artifact.workers[0]?.entries.some(
+                (entry) => entry.dateIn === "2026-02-04",
+            ),
+        ).toBe(false);
+    });
+
+    it("writes a real .xls workbook and JSON handoff that round-trip through the AttendRecord parser", async () => {
+        const tempDir = await mkdtemp(
+            path.join(os.tmpdir(), "february-attendrecord-artifacts-"),
+        );
+        const workbookPath = path.join(tempDir, "generated-attendrecord.xls");
+        const handoffPath = path.join(tempDir, "attendrecord-handoff.json");
+        const artifact = withWorkbookPath(
+            buildFebruary2026AttendRecordArtifact(buildWorkerHandoff()),
+            workbookPath,
+        );
+
+        try {
+            await writeFebruary2026AttendRecordArtifacts(artifact, handoffPath);
+
+            const written = JSON.parse(
+                await readFile(handoffPath, "utf8"),
+            ) as FebruaryAttendRecordArtifactHandoff;
+
+            expect(written).toEqual(artifact);
+
+            const parsedWorkbook = parseGeneratedAttendRecordWorkbook(workbookPath);
+
+            expect(parsedWorkbook.attendanceDate).toEqual(artifact.attendanceDate);
+            expect(parsedWorkbook.tablingDate).toBe(artifact.tablingDate);
+            expect(parsedWorkbook.workers.map((worker) => worker.name)).toEqual(
+                artifact.workers.map((worker) => worker.workerAlias),
+            );
+            expect(parsedWorkbook.workers.map((worker) => worker.userId)).toEqual(
+                artifact.workers.map((worker) => worker.aliasUserId),
+            );
+            expect(
+                parsedWorkbook.workers.map((worker) => worker.dates.length),
+            ).toEqual(artifact.workers.map((worker) => worker.totalImportedRows));
+
+            const parsedRowSignatures = parsedWorkbook.workers.flatMap(
+                (parsedWorker, index) =>
+                    parsedWorker.dates.map((date) =>
+                        [
+                            artifact.workers[index]?.workerName ?? "",
+                            date.dateIn,
+                            date.dateOut,
+                            date.timeIn,
+                            date.timeOut,
+                            (
+                                artifact.workers[index]?.entries.find(
+                                    (entry) => entry.dateIn === toIsoDate(date.dateIn),
+                                )?.totalHours ?? 0
+                            ).toFixed(2),
+                        ].join(" | "),
+                    ),
+            );
+
+            expect(parsedRowSignatures).toEqual(
+                artifact.workers.flatMap((worker) =>
+                    worker.entries.map((entry) => entry.rowSignature),
+                ),
+            );
+        } finally {
+            await rm(tempDir, { recursive: true, force: true });
+        }
+    });
+});
+
+function buildWorkerHandoff() {
+    return {
+        runId: "run-123",
+        workers: WORKER_USERFLOW_PERMUTATIONS.map((permutation, index) => ({
+            permutationKey: permutation.key,
+            workerId: `worker-${index + 1}`,
+            initialValues: {
+                name: `Worker ${index + 1} Edited`,
+                nric: `T000000${index}A`,
+                email: `worker-${index + 1}@example.com`,
+                phone: `8000000${index}`,
+                employmentType: permutation.employmentType,
+                employmentArrangement: permutation.employmentArrangement,
+                paymentMethod: permutation.paymentMethod,
+                hourlyRate: permutation.hourlyRate,
+                monthlyPay: permutation.monthlyPay ?? null,
+                restDayRate: permutation.restDayRate ?? null,
+                minimumWorkingHours: permutation.minimumWorkingHours ?? null,
+                cpf: permutation.cpf ?? null,
+                countryOfOrigin: permutation.countryOfOrigin ?? null,
+                bankAccountNumber: permutation.bankAccountNumber ?? null,
+                payNowPhone: permutation.payNowPhone ?? null,
+            },
+        })),
+    };
+}
+
+function withWorkbookPath(
+    artifact: FebruaryAttendRecordArtifactHandoff,
+    workbookPath: string,
+): FebruaryAttendRecordArtifactHandoff {
+    return {
+        ...artifact,
+        workbookPath,
+    };
+}
+
+function toIsoDate(displayDate: string): string {
+    const [day, month, year] = displayDate.split("/");
+
+    return `${year}-${month}-${day}`;
+}

--- a/test/userflow/timesheets/february-attendrecord-artifact-helpers.ts
+++ b/test/userflow/timesheets/february-attendrecord-artifact-helpers.ts
@@ -1,0 +1,376 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+import * as XLSX from "xlsx";
+
+import { parseAttendRecord } from "@/utils/payroll/parse-attendrecord";
+
+import {
+    USERFLOW_PERSISTED_ARTIFACTS_DIR,
+    WORKER_USERFLOW_PERMUTATIONS,
+    type WorkerUserflowHandoff,
+    type WorkerUserflowHandoffRecord,
+    type WorkerUserflowPermutation,
+} from "../workers/worker-userflow-helpers";
+import {
+    buildTimesheetRowSignature,
+    readWorkerUserflowHandoffForTimesheets,
+} from "./timesheet-userflow-helpers";
+
+export const FEBRUARY_2026_MONTH = "2026-02" as const;
+
+export const FEBRUARY_2026_ATTEND_RECORD_HANDOFF_PATH = path.join(
+    USERFLOW_PERSISTED_ARTIFACTS_DIR,
+    "timesheet-february-2026-attendrecord-handoff.json",
+);
+
+export type FebruaryAttendRecordShiftTemplate = {
+    timeIn: string;
+    timeOut: string;
+};
+
+export type FebruaryAttendRecordEntryPayload = {
+    workerId: string;
+    workerName: string;
+    workerAlias: string;
+    aliasUserId: string;
+    permutationKey: WorkerUserflowPermutation["key"];
+    dateIn: string;
+    dateOut: string;
+    timeIn: string;
+    timeOut: string;
+    totalHours: number;
+    rowSignature: string;
+};
+
+export type FebruaryAttendRecordWorkerDataset = {
+    workerId: string;
+    workerName: string;
+    workerAlias: string;
+    aliasUserId: string;
+    permutationKey: WorkerUserflowPermutation["key"];
+    shiftTemplate: FebruaryAttendRecordShiftTemplate;
+    missingDates: string[];
+    totalImportedRows: number;
+    totalHours: number;
+    entries: FebruaryAttendRecordEntryPayload[];
+};
+
+export type FebruaryAttendRecordArtifactHandoff = {
+    runId: string;
+    month: typeof FEBRUARY_2026_MONTH;
+    attendanceDate: {
+        startDate: string;
+        endDate: string;
+    };
+    tablingDate: string;
+    workbookPath: string;
+    expectedRowCount: number;
+    workers: FebruaryAttendRecordWorkerDataset[];
+};
+
+type PermutationKey = WorkerUserflowPermutation["key"];
+
+type FebruaryPermutationSpec = {
+    shiftTemplate: FebruaryAttendRecordShiftTemplate;
+    missingDates: readonly string[];
+};
+
+const EXPECTED_PERMUTATION_KEYS = WORKER_USERFLOW_PERMUTATIONS.map(
+    (permutation) => permutation.key,
+);
+
+const FEBRUARY_2026_ATTENDANCE_DATE = {
+    startDate: "01/02/2026",
+    endDate: "28/02/2026",
+} as const;
+
+const FEBRUARY_2026_TABLING_DATE = "28/02/2026 23:59:59" as const;
+
+const FEBRUARY_2026_ALL_DATES = Array.from({ length: 28 }, (_, index) =>
+    `2026-02-${String(index + 1).padStart(2, "0")}`,
+);
+
+const FEBRUARY_2026_IMPORT_SPECS: Record<PermutationKey, FebruaryPermutationSpec> = {
+    "full-time-local-bank-transfer": {
+        shiftTemplate: {
+            timeIn: "08:00",
+            timeOut: "19:00",
+        },
+        missingDates: [
+            "2026-02-04",
+            "2026-02-11",
+            "2026-02-18",
+            "2026-02-25",
+        ],
+    },
+    "full-time-foreign-paynow": {
+        shiftTemplate: {
+            timeIn: "09:00",
+            timeOut: "19:00",
+        },
+        missingDates: ["2026-02-08", "2026-02-22"],
+    },
+    "part-time-foreign-cash": {
+        shiftTemplate: {
+            timeIn: "08:30",
+            timeOut: "19:00",
+        },
+        missingDates: ["2026-02-03", "2026-02-10", "2026-02-17"],
+    },
+    "part-time-local-paynow": {
+        shiftTemplate: {
+            timeIn: "09:30",
+            timeOut: "19:00",
+        },
+        missingDates: ["2026-02-14"],
+    },
+};
+
+export function buildFebruary2026AttendRecordArtifact(
+    handoff: WorkerUserflowHandoff,
+): FebruaryAttendRecordArtifactHandoff {
+    const orderedWorkers = orderWorkerHandoffRecords(handoff);
+    const workbookPath = buildWorkbookPath(handoff.runId);
+    const workers = orderedWorkers.map((worker, index) =>
+        buildFebruary2026WorkerDataset(worker, index, handoff.runId),
+    );
+
+    return {
+        runId: handoff.runId,
+        month: FEBRUARY_2026_MONTH,
+        attendanceDate: FEBRUARY_2026_ATTENDANCE_DATE,
+        tablingDate: FEBRUARY_2026_TABLING_DATE,
+        workbookPath,
+        expectedRowCount: workers.reduce(
+            (sum, worker) => sum + worker.totalImportedRows,
+            0,
+        ),
+        workers,
+    };
+}
+
+export async function createFebruary2026AttendRecordArtifactsFromLatestWorkerHandoff(
+    handoffPath?: string,
+    artifactPath = FEBRUARY_2026_ATTEND_RECORD_HANDOFF_PATH,
+): Promise<FebruaryAttendRecordArtifactHandoff> {
+    const handoff = await readWorkerUserflowHandoffForTimesheets(handoffPath);
+    const artifact = buildFebruary2026AttendRecordArtifact(handoff);
+
+    await writeFebruary2026AttendRecordArtifacts(artifact, artifactPath);
+
+    return artifact;
+}
+
+export async function writeFebruary2026AttendRecordArtifacts(
+    artifact: FebruaryAttendRecordArtifactHandoff,
+    handoffPath = FEBRUARY_2026_ATTEND_RECORD_HANDOFF_PATH,
+): Promise<void> {
+    await mkdir(path.dirname(artifact.workbookPath), { recursive: true });
+    writeAttendRecordWorkbook(artifact);
+
+    await mkdir(path.dirname(handoffPath), { recursive: true });
+    await writeFile(handoffPath, `${JSON.stringify(artifact, null, 2)}\n`, "utf8");
+}
+
+export async function readFebruary2026AttendRecordArtifact(
+    handoffPath = FEBRUARY_2026_ATTEND_RECORD_HANDOFF_PATH,
+): Promise<FebruaryAttendRecordArtifactHandoff> {
+    const raw = await readFile(handoffPath, "utf8");
+
+    return JSON.parse(raw) as FebruaryAttendRecordArtifactHandoff;
+}
+
+export function parseGeneratedAttendRecordWorkbook(
+    workbookPath: string,
+) {
+    const workbook = XLSX.readFile(workbookPath);
+    const recordTableSheet = workbook.Sheets.RecordTable;
+
+    if (!recordTableSheet) {
+        throw new Error(
+            `Generated AttendRecord workbook at ${workbookPath} is missing the RecordTable sheet.`,
+        );
+    }
+
+    const rows = XLSX.utils.sheet_to_json(recordTableSheet, {
+        header: 1,
+        blankrows: true,
+        raw: false,
+    }) as (string | number | null)[][];
+
+    return parseAttendRecord(rows);
+}
+
+function buildFebruary2026WorkerDataset(
+    worker: WorkerUserflowHandoffRecord,
+    index: number,
+    runId: string,
+): FebruaryAttendRecordWorkerDataset {
+    const spec = FEBRUARY_2026_IMPORT_SPECS[worker.permutationKey];
+    const workerAlias = buildWorkerAlias(worker.initialValues.name, index);
+    const aliasUserId = buildAliasUserId(runId, index);
+    const entries = FEBRUARY_2026_ALL_DATES.filter(
+        (date) => !spec.missingDates.includes(date),
+    ).map((date) =>
+        buildFebruaryAttendRecordEntry(
+            worker,
+            workerAlias,
+            aliasUserId,
+            date,
+            spec.shiftTemplate,
+        ),
+    );
+
+    return {
+        workerId: worker.workerId,
+        workerName: worker.initialValues.name,
+        workerAlias,
+        aliasUserId,
+        permutationKey: worker.permutationKey,
+        shiftTemplate: spec.shiftTemplate,
+        missingDates: [...spec.missingDates],
+        totalImportedRows: entries.length,
+        totalHours: roundHours(
+            entries.reduce((sum, entry) => sum + entry.totalHours, 0),
+        ),
+        entries,
+    };
+}
+
+function buildFebruaryAttendRecordEntry(
+    worker: WorkerUserflowHandoffRecord,
+    workerAlias: string,
+    aliasUserId: string,
+    date: string,
+    shiftTemplate: FebruaryAttendRecordShiftTemplate,
+): FebruaryAttendRecordEntryPayload {
+    const entry = {
+        workerId: worker.workerId,
+        workerName: worker.initialValues.name,
+        workerAlias,
+        aliasUserId,
+        permutationKey: worker.permutationKey,
+        dateIn: date,
+        dateOut: date,
+        timeIn: shiftTemplate.timeIn,
+        timeOut: shiftTemplate.timeOut,
+        totalHours: calculateShiftHours(date, shiftTemplate),
+    };
+
+    return {
+        ...entry,
+        rowSignature: buildTimesheetRowSignature(entry),
+    };
+}
+
+function writeAttendRecordWorkbook(
+    artifact: FebruaryAttendRecordArtifactHandoff,
+): void {
+    const workbook = XLSX.utils.book_new();
+    const worksheet = XLSX.utils.aoa_to_sheet(buildAttendRecordRows(artifact));
+
+    XLSX.utils.book_append_sheet(workbook, worksheet, "RecordTable");
+    XLSX.writeFile(workbook, artifact.workbookPath, { bookType: "xls" });
+}
+
+function buildAttendRecordRows(
+    artifact: FebruaryAttendRecordArtifactHandoff,
+): (string | number)[][] {
+    const rows: (string | number)[][] = [
+        [
+            `Attendance date:${artifact.attendanceDate.startDate} ~${artifact.attendanceDate.endDate}`,
+        ],
+        [`Tabling date:${artifact.tablingDate}`],
+    ];
+
+    for (const worker of artifact.workers) {
+        rows.push(["UserID:", "", worker.aliasUserId, "Name:", worker.workerAlias]);
+        rows.push(["", "", "", "", "", ...buildDayHeaders()]);
+        rows.push([
+            "",
+            "",
+            "",
+            "",
+            "",
+            ...buildWorkbookDayCells(worker),
+        ]);
+        rows.push([]);
+    }
+
+    return rows;
+}
+
+function buildWorkbookDayCells(
+    worker: FebruaryAttendRecordWorkerDataset,
+): string[] {
+    const entryByDate = new Map(
+        worker.entries.map((entry) => [
+            entry.dateIn,
+            `${entry.timeIn}\n${entry.timeOut}`,
+        ]),
+    );
+
+    return FEBRUARY_2026_ALL_DATES.map((date) => entryByDate.get(date) ?? "");
+}
+
+function buildDayHeaders(): number[] {
+    return Array.from({ length: 28 }, (_, index) => index + 1);
+}
+
+function buildWorkerAlias(workerName: string, index: number): string {
+    const normalizedName = workerName.replace(/\s+Edited$/, "");
+
+    return `AttendRecord ${index + 1} ${normalizedName}`;
+}
+
+function buildAliasUserId(runId: string, index: number): string {
+    const runSuffix = runId.replace(/\W+/g, "").slice(-8).toUpperCase();
+
+    return `ATT-${runSuffix}-${String(index + 1).padStart(2, "0")}`;
+}
+
+function buildWorkbookPath(runId: string): string {
+    return path.join(
+        USERFLOW_PERSISTED_ARTIFACTS_DIR,
+        `timesheet-february-2026-attendrecord-${sanitizeRunId(runId)}.xls`,
+    );
+}
+
+function sanitizeRunId(runId: string): string {
+    return runId.replace(/[^a-zA-Z0-9-_]/g, "-");
+}
+
+function calculateShiftHours(
+    date: string,
+    shiftTemplate: FebruaryAttendRecordShiftTemplate,
+): number {
+    const start = new Date(`${date}T${shiftTemplate.timeIn}:00`);
+    const end = new Date(`${date}T${shiftTemplate.timeOut}:00`);
+
+    return roundHours((end.getTime() - start.getTime()) / 3_600_000);
+}
+
+function roundHours(value: number): number {
+    return Math.round(value * 100) / 100;
+}
+
+function orderWorkerHandoffRecords(
+    handoff: WorkerUserflowHandoff,
+): WorkerUserflowHandoffRecord[] {
+    const recordsByPermutation = new Map(
+        handoff.workers.map((worker) => [worker.permutationKey, worker]),
+    );
+
+    return EXPECTED_PERMUTATION_KEYS.map((permutationKey) => {
+        const worker = recordsByPermutation.get(permutationKey);
+
+        if (!worker) {
+            throw new Error(
+                `Worker userflow handoff is missing permutation ${permutationKey}.`,
+            );
+        }
+
+        return worker;
+    });
+}

--- a/test/userflow/timesheets/timesheet-import-userflow-playwright-helpers.test.ts
+++ b/test/userflow/timesheets/timesheet-import-userflow-playwright-helpers.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+
+import {
+    buildFebruary2026AttendRecordArtifact,
+    type FebruaryAttendRecordArtifactHandoff,
+} from "./february-attendrecord-artifact-helpers";
+import {
+    buildExpectedFebruaryImportedRowsByWorker,
+    buildExpectedFebruaryPreviewWorkerGroups,
+} from "./timesheet-import-userflow-playwright-helpers";
+import {
+    WORKER_USERFLOW_PERMUTATIONS,
+    type WorkerUserflowHandoff,
+} from "../workers/worker-userflow-helpers";
+
+describe("timesheet-import-userflow-playwright-helpers", () => {
+    it("builds preview group expectations from the generated February artifact", () => {
+        const artifact = buildArtifact();
+
+        expect(buildExpectedFebruaryPreviewWorkerGroups(artifact)).toEqual([
+            { workerLabel: "AttendRecord 1 Worker 1", rowCount: 24 },
+            { workerLabel: "AttendRecord 2 Worker 2", rowCount: 26 },
+            { workerLabel: "AttendRecord 3 Worker 3", rowCount: 25 },
+            { workerLabel: "AttendRecord 4 Worker 4", rowCount: 27 },
+        ]);
+    });
+
+    it("builds imported-row expectations keyed by edited app worker names", () => {
+        const artifact = buildArtifact();
+        const importedRowsByWorker =
+            buildExpectedFebruaryImportedRowsByWorker(artifact);
+
+        expect(importedRowsByWorker.map((worker) => worker.workerName)).toEqual([
+            "Worker 1 Edited",
+            "Worker 2 Edited",
+            "Worker 3 Edited",
+            "Worker 4 Edited",
+        ]);
+
+        expect(importedRowsByWorker.map((worker) => worker.rowSignatures)).toEqual(
+            artifact.workers.map((worker) =>
+                worker.entries.map((entry) => entry.rowSignature),
+            ),
+        );
+    });
+});
+
+function buildArtifact(): FebruaryAttendRecordArtifactHandoff {
+    return buildFebruary2026AttendRecordArtifact({
+        runId: "run-123",
+        workers: WORKER_USERFLOW_PERMUTATIONS.map((permutation, index) => ({
+            permutationKey: permutation.key,
+            workerId: `worker-${index + 1}`,
+            initialValues: {
+                name: `Worker ${index + 1} Edited`,
+                nric: `T000000${index}A`,
+                email: `worker-${index + 1}@example.com`,
+                phone: `8000000${index}`,
+                employmentType: permutation.employmentType,
+                employmentArrangement: permutation.employmentArrangement,
+                paymentMethod: permutation.paymentMethod,
+                hourlyRate: permutation.hourlyRate,
+                monthlyPay: permutation.monthlyPay ?? null,
+                restDayRate: permutation.restDayRate ?? null,
+                minimumWorkingHours: permutation.minimumWorkingHours ?? null,
+                cpf: permutation.cpf ?? null,
+                countryOfOrigin: permutation.countryOfOrigin ?? null,
+                bankAccountNumber: permutation.bankAccountNumber ?? null,
+                payNowPhone: permutation.payNowPhone ?? null,
+            },
+        })),
+    } satisfies WorkerUserflowHandoff);
+}

--- a/test/userflow/timesheets/timesheet-import-userflow-playwright-helpers.ts
+++ b/test/userflow/timesheets/timesheet-import-userflow-playwright-helpers.ts
@@ -80,12 +80,7 @@ export async function assertFebruaryImportPreviewBeforeRemapping(
     );
 
     for (const worker of artifact.workers) {
-        await expect(
-            page.getByRole("combobox", {
-                name: worker.workerAlias,
-                exact: true,
-            }),
-        ).toBeVisible();
+        await expect(getPreviewWorkerCombobox(page, worker.workerAlias)).toBeVisible();
     }
 }
 
@@ -94,23 +89,19 @@ export async function remapFebruaryImportPreviewWorkers(
     artifact: FebruaryAttendRecordArtifactHandoff,
 ): Promise<void> {
     for (const worker of artifact.workers) {
-        await page
-            .getByRole("combobox", {
-                name: worker.workerAlias,
-                exact: true,
-            })
-            .click();
-        await page.getByPlaceholder(/Search workers/i).fill(worker.workerName);
-        await page
-            .getByRole("option", { name: worker.workerName, exact: true })
-            .click();
+        const combobox = getPreviewWorkerCombobox(page, worker.workerAlias);
 
-        await expect(
-            page.getByRole("combobox", {
-                name: worker.workerName,
-                exact: true,
-            }),
-        ).toBeVisible();
+        await closeVisibleWorkerSearchPopovers(page);
+        await combobox.click();
+
+        const searchInput = getVisibleWorkerSearchInput(page);
+
+        await expect(searchInput).toBeVisible();
+        await searchInput.fill(worker.workerName);
+        await getVisibleWorkerOption(page, worker.workerName).click();
+
+        await expect(getPreviewWorkerRow(page, worker.workerName)).toBeVisible();
+        await closeVisibleWorkerSearchPopovers(page);
     }
 }
 
@@ -218,4 +209,39 @@ function buildExpectedSignatureCounts(
 
         return counts;
     }, {});
+}
+
+function getPreviewWorkerCombobox(page: Page, workerLabel: string) {
+    return getPreviewWorkerRow(page, workerLabel).getByRole("combobox");
+}
+
+function getPreviewWorkerRow(page: Page, workerLabel: string) {
+    return getTimesheetTable(page)
+        .locator("tbody tr")
+        .filter({
+            has: page.getByText(workerLabel, { exact: true }),
+        })
+        .first();
+}
+
+function getVisibleWorkerSearchInput(page: Page) {
+    return page.locator('input[placeholder^="Search workers"]:visible').last();
+}
+
+function getVisibleWorkerOption(page: Page, workerName: string) {
+    return page
+        .locator('[role="option"]:visible')
+        .filter({ hasText: workerName })
+        .last();
+}
+
+async function closeVisibleWorkerSearchPopovers(page: Page): Promise<void> {
+    const visibleSearchInputs = page.locator(
+        'input[placeholder^="Search workers"]:visible',
+    );
+    const openCount = await visibleSearchInputs.count();
+
+    for (let index = 0; index < openCount; index += 1) {
+        await page.keyboard.press("Escape");
+    }
 }

--- a/test/userflow/timesheets/timesheet-import-userflow-playwright-helpers.ts
+++ b/test/userflow/timesheets/timesheet-import-userflow-playwright-helpers.ts
@@ -1,0 +1,221 @@
+import path from "node:path";
+
+import { expect, type Page } from "@playwright/test";
+
+import type { FebruaryAttendRecordArtifactHandoff } from "./february-attendrecord-artifact-helpers";
+import {
+    collectVisibleRowSignaturesAcrossPages,
+    getTimesheetSearchInput,
+    getTimesheetTable,
+} from "./timesheet-userflow-playwright-helpers";
+
+type FebruaryPreviewWorkerGroupExpectation = {
+    workerLabel: string;
+    rowCount: number;
+};
+
+type FebruaryImportedRowsByWorker = {
+    workerName: string;
+    rowSignatures: string[];
+};
+
+export function buildExpectedFebruaryPreviewWorkerGroups(
+    artifact: FebruaryAttendRecordArtifactHandoff,
+): FebruaryPreviewWorkerGroupExpectation[] {
+    return artifact.workers.map((worker) => ({
+        workerLabel: worker.workerAlias,
+        rowCount: worker.totalImportedRows,
+    }));
+}
+
+export function buildExpectedFebruaryImportedRowsByWorker(
+    artifact: FebruaryAttendRecordArtifactHandoff,
+): FebruaryImportedRowsByWorker[] {
+    return artifact.workers.map((worker) => ({
+        workerName: worker.workerName,
+        rowSignatures: worker.entries.map((entry) => entry.rowSignature),
+    }));
+}
+
+export async function uploadFebruaryAttendRecordWorkbook(
+    page: Page,
+    artifact: FebruaryAttendRecordArtifactHandoff,
+): Promise<void> {
+    await page.goto("/dashboard/timesheet/import");
+    await expect(
+        page.getByRole("heading", { name: "Import timesheet" }).first(),
+    ).toBeVisible();
+
+    await page
+        .locator('input[type="file"]')
+        .setInputFiles(artifact.workbookPath);
+
+    await expect(
+        page.getByText(path.basename(artifact.workbookPath), { exact: true }),
+    ).toBeVisible();
+}
+
+export async function assertFebruaryImportPreviewBeforeRemapping(
+    page: Page,
+    artifact: FebruaryAttendRecordArtifactHandoff,
+): Promise<void> {
+    await expect(
+        page.getByText(
+            `Attendance period: ${artifact.attendanceDate.startDate} ~ ${artifact.attendanceDate.endDate}`,
+            { exact: true },
+        ),
+    ).toBeVisible();
+    await expect(
+        page.getByText(`Tabling date: ${artifact.tablingDate}`, { exact: true }),
+    ).toBeVisible();
+    await expect(
+        page.getByText(
+            `${artifact.workers.length} workers, ${artifact.expectedRowCount} entries total`,
+            { exact: true },
+        ),
+    ).toBeVisible();
+
+    expect(await readRenderedPreviewWorkerGroups(page)).toEqual(
+        buildExpectedFebruaryPreviewWorkerGroups(artifact),
+    );
+
+    for (const worker of artifact.workers) {
+        await expect(
+            page.getByRole("combobox", {
+                name: worker.workerAlias,
+                exact: true,
+            }),
+        ).toBeVisible();
+    }
+}
+
+export async function remapFebruaryImportPreviewWorkers(
+    page: Page,
+    artifact: FebruaryAttendRecordArtifactHandoff,
+): Promise<void> {
+    for (const worker of artifact.workers) {
+        await page
+            .getByRole("combobox", {
+                name: worker.workerAlias,
+                exact: true,
+            })
+            .click();
+        await page.getByPlaceholder(/Search workers/i).fill(worker.workerName);
+        await page
+            .getByRole("option", { name: worker.workerName, exact: true })
+            .click();
+
+        await expect(
+            page.getByRole("combobox", {
+                name: worker.workerName,
+                exact: true,
+            }),
+        ).toBeVisible();
+    }
+}
+
+export async function submitFebruaryAttendRecordImport(
+    page: Page,
+    artifact: FebruaryAttendRecordArtifactHandoff,
+): Promise<void> {
+    await page.getByRole("button", { name: "Upload Timesheet" }).click();
+
+    await expect(
+        page.getByText(`Imported ${artifact.expectedRowCount} entries.`, {
+            exact: true,
+        }),
+    ).toBeVisible();
+}
+
+export async function verifyFebruaryImportedRowsInAllTimesheetsUi(
+    page: Page,
+    artifact: FebruaryAttendRecordArtifactHandoff,
+): Promise<void> {
+    await page.goto("/dashboard/timesheet/all");
+    await expect(
+        page.getByRole("heading", { name: "All timesheets" }),
+    ).toBeVisible();
+
+    for (const expectedWorker of buildExpectedFebruaryImportedRowsByWorker(
+        artifact,
+    )) {
+        const searchInput = getTimesheetSearchInput(page);
+
+        await searchInput.fill(expectedWorker.workerName);
+        await expect(
+            getTimesheetTable(page)
+                .getByRole("cell", { name: expectedWorker.workerName })
+                .first(),
+        ).toBeVisible();
+
+        const actualSignatures = await collectVisibleRowSignaturesAcrossPages(page);
+        const actualExpectedCounts = countMatchingSignatures(
+            actualSignatures,
+            expectedWorker.rowSignatures,
+        );
+
+        expect(actualExpectedCounts).toEqual(
+            buildExpectedSignatureCounts(expectedWorker.rowSignatures),
+        );
+    }
+}
+
+async function readRenderedPreviewWorkerGroups(
+    page: Page,
+): Promise<FebruaryPreviewWorkerGroupExpectation[]> {
+    return getTimesheetTable(page)
+        .locator("tbody tr")
+        .evaluateAll((rows) => {
+            const groups: { workerLabel: string; rowCount: number }[] = [];
+
+            for (const row of rows) {
+                const firstCellText =
+                    row.querySelector("td")?.textContent
+                        ?.replace(/\s+/g, " ")
+                        .trim() ?? "";
+
+                if (firstCellText && firstCellText !== "└") {
+                    groups.push({
+                        workerLabel: firstCellText,
+                        rowCount: 1,
+                    });
+                    continue;
+                }
+
+                const currentGroup = groups.at(-1);
+
+                if (currentGroup) {
+                    currentGroup.rowCount += 1;
+                }
+            }
+
+            return groups;
+        });
+}
+
+function countMatchingSignatures(
+    actualSignatures: string[],
+    expectedSignatures: string[],
+): Record<string, number> {
+    const expectedSignatureSet = new Set(expectedSignatures);
+
+    return actualSignatures.reduce<Record<string, number>>((counts, signature) => {
+        if (!expectedSignatureSet.has(signature)) {
+            return counts;
+        }
+
+        counts[signature] = (counts[signature] ?? 0) + 1;
+
+        return counts;
+    }, {});
+}
+
+function buildExpectedSignatureCounts(
+    expectedSignatures: string[],
+): Record<string, number> {
+    return expectedSignatures.reduce<Record<string, number>>((counts, signature) => {
+        counts[signature] = (counts[signature] ?? 0) + 1;
+
+        return counts;
+    }, {});
+}

--- a/test/userflow/timesheets/timesheet-userflow-helpers.ts
+++ b/test/userflow/timesheets/timesheet-userflow-helpers.ts
@@ -43,6 +43,11 @@ export type MarchTimesheetWorkerDataset = {
     entries: MarchTimesheetEntryPayload[];
 };
 
+type TimesheetRowSignatureInput = Pick<
+    MarchTimesheetEntryPayload,
+    "workerName" | "dateIn" | "dateOut" | "timeIn" | "timeOut" | "totalHours"
+>;
+
 export type TimesheetUserflowHandoff = {
     runId: string;
     month: typeof MARCH_2026_MONTH;
@@ -130,7 +135,7 @@ export function buildMarch2026WorkerDataset(
 }
 
 export function buildTimesheetRowSignature(
-    entry: MarchTimesheetEntryPayload,
+    entry: TimesheetRowSignatureInput,
 ): string {
     return [
         entry.workerName,

--- a/test/userflow/timesheets/timesheet-userflow-playwright-helpers.ts
+++ b/test/userflow/timesheets/timesheet-userflow-playwright-helpers.ts
@@ -97,7 +97,7 @@ export async function verifyTimesheetDatasetInAllTimesheetsUi(
     }
 }
 
-async function collectVisibleRowSignaturesAcrossPages(
+export async function collectVisibleRowSignaturesAcrossPages(
     page: Page,
 ): Promise<string[]> {
     const signatures: string[] = [];
@@ -183,11 +183,11 @@ async function readRowSignature(row: ReturnType<Page["locator"]>): Promise<strin
     return cells.slice(0, 6).map((cell) => cell.trim()).join(" | ");
 }
 
-function getTimesheetSearchInput(page: Page) {
+export function getTimesheetSearchInput(page: Page) {
     return page.getByRole("main").getByPlaceholder("Search...");
 }
 
-function getTimesheetTable(page: Page) {
+export function getTimesheetTable(page: Page) {
     return page.getByRole("main").getByRole("table");
 }
 


### PR DESCRIPTION
## Summary

- February AttendRecord import userflow spec and Playwright helpers
- Staged userflow projects (worker-new → worker-edit → timesheet-march → timesheet-followups) with artifact hardening
- Merged latest `main`: advance userflow suite, Sandcastle updates, result-folder registration
- `playwright.userflow.config.ts`: keeps staged timesheets and adds `userflow-advance` after followups

## Notes

Branch was rebased/merged onto `main` before push; PR brings these changes into `main`.


Made with [Cursor](https://cursor.com)