### PR TITLE
Worker dashboard: FT pay and CPF metric cards

### DIFF
--- a/app/dashboard/worker/page.test.ts
+++ b/app/dashboard/worker/page.test.ts
@@ -13,29 +13,64 @@ vi.mock("@/lib/db", () => ({
 
 import { WorkerOverviewLoader } from "@/app/dashboard/worker/worker-overview-loader";
 
+function mockSelectSequence(
+    results: [
+        groupBy: unknown,
+        activeCount: unknown,
+        fullTimeRows: unknown,
+        hoursAgg: unknown,
+    ],
+) {
+    const [r0, r1, r2, r3] = results;
+    mocks.db.select
+        .mockReturnValueOnce({
+            from: vi.fn().mockReturnValue({
+                innerJoin: vi.fn().mockReturnValue({
+                    where: vi.fn().mockReturnValue({
+                        groupBy: vi.fn().mockResolvedValue(r0),
+                    }),
+                }),
+            }),
+        })
+        .mockReturnValueOnce({
+            from: vi.fn().mockReturnValue({
+                where: vi.fn().mockResolvedValue(r1),
+            }),
+        })
+        .mockReturnValueOnce({
+            from: vi.fn().mockReturnValue({
+                innerJoin: vi.fn().mockReturnValue({
+                    where: vi.fn().mockReturnValue({
+                        orderBy: vi.fn().mockResolvedValue(r2),
+                    }),
+                }),
+            }),
+        })
+        .mockReturnValueOnce({
+            from: vi.fn().mockReturnValue({
+                innerJoin: vi.fn().mockReturnValue({
+                    where: vi.fn().mockResolvedValue(r3),
+                }),
+            }),
+        });
+}
+
 describe("WorkerOverviewLoader", () => {
     beforeEach(() => {
         vi.clearAllMocks();
     });
 
-    it("renders totals and active/inactive breakdown", async () => {
-        mocks.db.select
-            .mockReturnValueOnce({
-                from: vi.fn().mockResolvedValue([{ total: 5 }]),
-            })
-            .mockReturnValueOnce({
-                from: vi.fn().mockReturnValue({
-                    where: vi.fn().mockResolvedValue([{ active: 3 }]),
-                }),
-            });
+    it("renders active worker count and key overview sections", async () => {
+        mockSelectSequence([[], [{ count: 3 }], [], [{ minHours: null, maxHours: null }]]);
 
         const html = renderToStaticMarkup(await WorkerOverviewLoader());
 
-        expect(html).toContain("Total workers");
-        expect(html).toContain("5");
-        expect(html).toContain("3 Active, 2 Inactive");
+        expect(html).toContain("Active workers");
+        expect(html).toContain("3");
         expect(html).toContain("View all workers");
         expect(html).toContain("New worker");
-        expect(html).toContain("Status breakdown");
+        expect(html).toContain("Full Time monthly pay");
+        expect(html).toContain("Local Full Time employee CPF");
+        expect(html).toContain("Workforce composition");
     });
 });

--- a/app/dashboard/worker/worker-overview-loader.tsx
+++ b/app/dashboard/worker/worker-overview-loader.tsx
@@ -122,16 +122,6 @@ export async function WorkerOverviewLoader() {
         (r) => r.arrangement === "Local Worker",
     );
 
-    const foreignFtMonthlyPayTotal = foreignFullTimeRows.reduce(
-        (acc, r) => acc + (r.monthlyPay ?? 0),
-        0,
-    );
-
-    const localFtEmployeeCpfTotal = localFullTimeRows.reduce(
-        (acc, r) => acc + (r.cpf ?? 0),
-        0,
-    );
-
     const [hoursRow] = foreignFtHoursAgg;
     const minHours =
         hoursRow?.minHours != null ? Number(hoursRow.minHours) : null;
@@ -180,44 +170,46 @@ export async function WorkerOverviewLoader() {
                 ]}
             />
 
-            <div className="grid grid-cols-2 gap-4">
-                <Card>
-                    <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-                        <CardTitle className="text-sm font-medium">
-                            Active workers
-                        </CardTitle>
-                        <Users className="text-muted-foreground size-4" />
-                    </CardHeader>
-                    <CardContent>
-                        <div className="text-2xl font-bold">{activeCount}</div>
-                        <p className="text-muted-foreground text-xs">
-                            Workers with Active status
-                        </p>
-                    </CardContent>
-                </Card>
-                <Card>
-                    <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-                        <CardTitle className="text-sm font-medium">
-                            Min. hours (Foreign FT)
-                        </CardTitle>
-                        <Clock className="text-muted-foreground size-4" />
-                    </CardHeader>
-                    <CardContent>
-                        <div className="text-2xl font-bold tabular-nums">
-                            {foreignFtMinHoursRangeLabel}
-                        </div>
-                        <p className="text-muted-foreground text-xs">
-                            Range of minimum working hours on employment for
-                            active Foreign Worker, Full Time staff
-                        </p>
-                    </CardContent>
-                </Card>
-                <FullTimeMonthlyPayCard
-                    totalMonthlyPay={foreignFtMonthlyPayTotal}
-                />
-                <LocalFullTimeEmployeeCpfCard
-                    totalEmployeeCpf={localFtEmployeeCpfTotal}
-                />
+            <div className="space-y-4">
+                <div className="grid grid-cols-2 gap-4">
+                    <Card>
+                        <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                            <CardTitle className="text-sm font-medium">
+                                Active workers
+                            </CardTitle>
+                            <Users className="text-muted-foreground size-4" />
+                        </CardHeader>
+                        <CardContent>
+                            <div className="text-2xl font-bold">
+                                {activeCount}
+                            </div>
+                            <p className="text-muted-foreground text-xs">
+                                Workers with Active status
+                            </p>
+                        </CardContent>
+                    </Card>
+                    <Card>
+                        <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                            <CardTitle className="text-sm font-medium">
+                                Min. hours (Foreign FT)
+                            </CardTitle>
+                            <Clock className="text-muted-foreground size-4" />
+                        </CardHeader>
+                        <CardContent>
+                            <div className="text-2xl font-bold tabular-nums">
+                                {foreignFtMinHoursRangeLabel}
+                            </div>
+                            <p className="text-muted-foreground text-xs">
+                                Range of minimum working hours on employment for
+                                active Foreign Worker, Full Time staff
+                            </p>
+                        </CardContent>
+                    </Card>
+                </div>
+                <div className="w-full space-y-4">
+                    <FullTimeMonthlyPayCard rows={foreignFullTimeRows} />
+                    <LocalFullTimeEmployeeCpfCard rows={localFullTimeRows} />
+                </div>
             </div>
 
             <WorkerCompositionCard buckets={buckets} />

--- a/components/dashboard/full-time-monthly-pay-card.tsx
+++ b/components/dashboard/full-time-monthly-pay-card.tsx
@@ -1,43 +1,25 @@
-import { Wallet } from "lucide-react";
-
 import {
-    Card,
-    CardContent,
-    CardHeader,
-    CardTitle,
-} from "@/components/ui/card";
+    SelectableWorkerMetricCard,
+    type SelectableWorkerMetricRow,
+} from "@/components/dashboard/selectable-worker-metric-card";
 
-const currencyFmt = new Intl.NumberFormat("en-US", {
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 2,
-});
+type ForeignFullTimeLine = {
+    id: string;
+    name: string;
+    monthlyPay: number | null;
+};
 
-function formatMoney(value: number): string {
-    return currencyFmt.format(value);
-}
-
-export function FullTimeMonthlyPayCard({
-    totalMonthlyPay,
-}: {
-    /** Sum of contracted monthly pay for active Foreign Full Time workers. */
-    totalMonthlyPay: number;
-}) {
+export function FullTimeMonthlyPayCard({ rows }: { rows: ForeignFullTimeLine[] }) {
+    const metricRows: SelectableWorkerMetricRow[] = rows.map((r) => ({
+        id: r.id,
+        name: r.name,
+        amount: r.monthlyPay ?? 0,
+    }));
     return (
-        <Card>
-            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-                <CardTitle className="text-sm font-medium">
-                    Full Time monthly pay
-                </CardTitle>
-                <Wallet className="text-muted-foreground size-4" />
-            </CardHeader>
-            <CardContent>
-                <div className="text-2xl font-bold tabular-nums">
-                    ${formatMoney(totalMonthlyPay)}
-                </div>
-                <p className="text-muted-foreground text-xs">
-                    Foreign Full Time — total contracted monthly pay
-                </p>
-            </CardContent>
-        </Card>
+        <SelectableWorkerMetricCard
+            title="Full Time monthly pay"
+            description="Foreign Full Time — total contracted monthly pay"
+            rows={metricRows}
+        />
     );
 }

--- a/components/dashboard/local-full-time-employee-cpf-card.tsx
+++ b/components/dashboard/local-full-time-employee-cpf-card.tsx
@@ -1,43 +1,29 @@
-import { Wallet } from "lucide-react";
-
 import {
-    Card,
-    CardContent,
-    CardHeader,
-    CardTitle,
-} from "@/components/ui/card";
+    SelectableWorkerMetricCard,
+    type SelectableWorkerMetricRow,
+} from "@/components/dashboard/selectable-worker-metric-card";
 
-const currencyFmt = new Intl.NumberFormat("en-US", {
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 2,
-});
-
-function formatMoney(value: number): string {
-    return currencyFmt.format(value);
-}
+type LocalFullTimeLine = {
+    id: string;
+    name: string;
+    cpf: number | null;
+};
 
 export function LocalFullTimeEmployeeCpfCard({
-    totalEmployeeCpf,
+    rows,
 }: {
-    /** Sum of employee CPF on employment for active Local Full Time workers. */
-    totalEmployeeCpf: number;
+    rows: LocalFullTimeLine[];
 }) {
+    const metricRows: SelectableWorkerMetricRow[] = rows.map((r) => ({
+        id: r.id,
+        name: r.name,
+        amount: r.cpf ?? 0,
+    }));
     return (
-        <Card>
-            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-                <CardTitle className="text-sm font-medium">
-                    Local Full Time employee CPF
-                </CardTitle>
-                <Wallet className="text-muted-foreground size-4" />
-            </CardHeader>
-            <CardContent>
-                <div className="text-2xl font-bold tabular-nums">
-                    ${formatMoney(totalEmployeeCpf)}
-                </div>
-                <p className="text-muted-foreground text-xs">
-                    Local Full Time — total employee CPF on employment
-                </p>
-            </CardContent>
-        </Card>
+        <SelectableWorkerMetricCard
+            title="Local Full Time employee CPF"
+            description="Local Full Time — total employee CPF on employment"
+            rows={metricRows}
+        />
     );
 }

--- a/components/dashboard/selectable-worker-metric-card.tsx
+++ b/components/dashboard/selectable-worker-metric-card.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { cn } from "@/lib/utils";
+
+const currencyFmt = new Intl.NumberFormat("en-US", {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+});
+
+function formatMoney(value: number): string {
+    return currencyFmt.format(value);
+}
+
+export type SelectableWorkerMetricRow = {
+    id: string;
+    name: string;
+    amount: number;
+};
+
+type Props = {
+    title: string;
+    description: string;
+    rows: SelectableWorkerMetricRow[];
+    searchPlaceholder?: string;
+};
+
+function rowsKey(rows: SelectableWorkerMetricRow[]): string {
+    return rows
+        .map((r) => r.id)
+        .sort()
+        .join("\0");
+}
+
+export function SelectableWorkerMetricCard({
+    title,
+    description,
+    rows,
+    searchPlaceholder = "Worker name",
+}: Props) {
+    const [nameFilter, setNameFilter] = useState("");
+    const [checked, setChecked] = useState<Record<string, boolean>>({});
+
+    const rowIdsKey = useMemo(() => rowsKey(rows), [rows]);
+    const rowsRef = useRef(rows);
+    useLayoutEffect(() => {
+        rowsRef.current = rows;
+    }, [rows]);
+
+    useEffect(() => {
+        setChecked(
+            Object.fromEntries(
+                rowsRef.current.map((r) => [r.id, true] as const),
+            ),
+        );
+    }, [rowIdsKey]);
+
+    const visibleRows = useMemo(() => {
+        const q = nameFilter.trim().toLowerCase();
+        if (q === "") {
+            return rows;
+        }
+        return rows.filter((r) => r.name.toLowerCase().includes(q));
+    }, [rows, nameFilter]);
+
+    const total = useMemo(
+        () =>
+            visibleRows.reduce(
+                (acc, r) =>
+                    (checked[r.id] ?? true) ? acc + r.amount : acc,
+                0,
+            ),
+        [visibleRows, checked],
+    );
+
+    const setRowChecked = (id: string, value: boolean) => {
+        setChecked((prev) => ({ ...prev, [id]: value }));
+    };
+
+    return (
+        <Card>
+            <CardHeader className="space-y-4 pb-2">
+                <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between sm:gap-4">
+                    <CardTitle className="text-lg font-semibold tracking-tight sm:text-xl">
+                        {title}
+                    </CardTitle>
+                    <div className="w-full min-w-0 sm:max-w-sm">
+                        <Input
+                            value={nameFilter}
+                            onChange={(e) => setNameFilter(e.target.value)}
+                            placeholder={searchPlaceholder}
+                            className="min-w-0"
+                            type="search"
+                            aria-label="Filter workers by name"
+                        />
+                    </div>
+                </div>
+            </CardHeader>
+            <CardContent>
+                <div className="flex flex-col gap-6 md:flex-row md:items-stretch">
+                    <div
+                        className={cn(
+                            "w-max min-w-xs max-w-full shrink-0",
+                            "h-48 space-y-3.5 overflow-y-auto pr-1 md:h-64",
+                        )}
+                    >
+                        {rows.length === 0 ? (
+                            <p className="text-muted-foreground text-sm">
+                                No active workers in this group.
+                            </p>
+                        ) : visibleRows.length === 0 ? (
+                            <p className="text-muted-foreground text-sm">
+                                No workers match this search.
+                            </p>
+                        ) : (
+                            visibleRows.map((r) => (
+                                <div
+                                    key={r.id}
+                                    className="flex w-max max-w-full min-w-0 items-center gap-3.5"
+                                >
+                                    <Checkbox
+                                        className="size-5"
+                                        id={`metric-${r.id}`}
+                                        checked={checked[r.id] ?? true}
+                                        onCheckedChange={(v) =>
+                                            setRowChecked(
+                                                r.id,
+                                                v === true,
+                                            )
+                                        }
+                                    />
+                                    <Label
+                                        htmlFor={`metric-${r.id}`}
+                                        className="cursor-pointer text-base font-normal whitespace-nowrap"
+                                    >
+                                        {r.name}
+                                    </Label>
+                                </div>
+                            ))
+                        )}
+                    </div>
+                    <div className="flex min-w-0 flex-1 flex-col items-center justify-center border-t pt-4 text-center md:min-w-[10rem] md:border-l md:border-t-0 md:pl-6 md:pt-0">
+                        <div className="text-4xl font-bold tabular-nums sm:text-5xl lg:text-6xl">
+                            ${formatMoney(total)}
+                        </div>
+                        <p className="text-muted-foreground mt-2 max-w-prose text-base sm:text-lg">
+                            {description}
+                        </p>
+                    </div>
+                </div>
+            </CardContent>
+        </Card>
+    );
+}


### PR DESCRIPTION
## Summary
- Full-width stacked cards for Foreign Full Time monthly pay and Local Full Time employee CPF
- `SelectableWorkerMetricCard`: per-worker checkboxes, live name filter, fixed list height, centered totals
- Server passes per-worker rows; no RSC icon props to client components
- Updates `WorkerOverviewLoader` unit test mocks and expectations

## Test plan
- [ ] Open /dashboard/worker and verify pay/CPF cards, filter, totals, layout

Made with [Cursor](https://cursor.com)