### PR TITLE
feat(timesheet): duplicate guard on AttendRecord import

### DIFF
--- a/app/api/timesheets/import/route.test.ts
+++ b/app/api/timesheets/import/route.test.ts
@@ -56,7 +56,9 @@ describe("POST /api/timesheets/import", () => {
         };
 
         mocks.importAttendRecordTimesheet.mockResolvedValue({
+            status: "success",
             imported: 1,
+            skipped: 0,
         });
 
         const response = await POST(
@@ -73,27 +75,33 @@ describe("POST /api/timesheets/import", () => {
         await expect(response.json()).resolves.toEqual({
             ok: true,
             data: {
+                status: "success",
                 imported: 1,
+                skipped: 0,
             },
         });
-        expect(mocks.importAttendRecordTimesheet).toHaveBeenCalledWith({
-            attendanceDate: payload.attendanceDate,
-            tablingDate: payload.tablingDate,
-            workers: [
-                {
-                    userId: "",
-                    name: "Worker One",
-                    dates: [
-                        {
-                            dateIn: "01/01/2026",
-                            timeIn: "09:00",
-                            dateOut: "01/01/2026",
-                            timeOut: "17:00",
-                        },
-                    ],
-                },
-            ],
-        });
+
+        expect(mocks.importAttendRecordTimesheet).toHaveBeenCalledWith(
+            {
+                attendanceDate: payload.attendanceDate,
+                tablingDate: payload.tablingDate,
+                workers: [
+                    {
+                        userId: "",
+                        name: "Worker One",
+                        dates: [
+                            {
+                                dateIn: "01/01/2026",
+                                timeIn: "09:00",
+                                dateOut: "01/01/2026",
+                                timeOut: "17:00",
+                            },
+                        ],
+                    },
+                ],
+            },
+            undefined,
+        );
         expect(mocks.revalidateTransportPaths).toHaveBeenCalledWith([
             "/dashboard",
             "/dashboard/timesheet",
@@ -109,6 +117,40 @@ describe("POST /api/timesheets/import", () => {
                 type: "page",
             },
         ]);
+    });
+
+    it("passes skip mode from the query string into the import service", async () => {
+        const payload = {
+            attendanceDate: {
+                startDate: "01/01/2026",
+                endDate: "28/01/2026",
+            },
+            tablingDate: "28/01/2026 17:10:10",
+            workers: [],
+        };
+
+        mocks.importAttendRecordTimesheet.mockResolvedValue({
+            status: "success",
+            imported: 0,
+            skipped: 0,
+        });
+
+        await POST(
+            new Request(
+                "http://localhost/api/timesheets/import?mode=skip",
+                {
+                    method: "POST",
+                    headers: {
+                        "Content-Type": "application/json",
+                    },
+                    body: JSON.stringify(payload),
+                },
+            ) as never,
+        );
+
+        expect(mocks.importAttendRecordTimesheet).toHaveBeenCalledWith(payload, {
+            mode: "skip",
+        });
     });
 
     it("returns 400 for invalid JSON", async () => {

--- a/app/api/timesheets/import/route.ts
+++ b/app/api/timesheets/import/route.ts
@@ -54,9 +54,17 @@ export async function POST(request: Request) {
         });
     }
 
-    const result = await importAttendRecordTimesheet(parsedBody.data);
+    const url = new URL(request.url);
+    const modeParam = url.searchParams.get("mode");
+    const mode =
+        modeParam === "skip" || modeParam === "force" ? modeParam : undefined;
 
-    if (result.imported > 0) {
+    const result = await importAttendRecordTimesheet(
+        parsedBody.data,
+        mode ? { mode } : undefined,
+    );
+
+    if (result.status === "success" && result.imported > 0) {
         revalidateTransportPaths([
             "/dashboard",
             "/dashboard/timesheet",

--- a/app/dashboard/timesheet/import/import-attend-record-timesheet.client.test.ts
+++ b/app/dashboard/timesheet/import/import-attend-record-timesheet.client.test.ts
@@ -42,13 +42,17 @@ describe("importAttendRecordTimesheet", () => {
             mockFetchJsonResponse({
                 ok: true,
                 data: {
+                    status: "success",
                     imported: 1,
+                    skipped: 0,
                 },
             }),
         );
 
         await expect(importAttendRecordTimesheet(payload)).resolves.toEqual({
+            status: "success",
             imported: 1,
+            skipped: 0,
         });
 
         expect(fetchMock).toHaveBeenCalledWith("/api/timesheets/import", {
@@ -88,7 +92,9 @@ describe("importAttendRecordTimesheet", () => {
             mockFetchJsonResponse({
                 ok: true,
                 data: {
+                    status: "success",
                     imported: 1,
+                    skipped: 0,
                 },
             }),
         );
@@ -146,6 +152,38 @@ describe("importAttendRecordTimesheet", () => {
             }),
         ).resolves.toEqual({
             error: "Forbidden",
+        });
+    });
+
+    it("appends mode to the import URL when provided", async () => {
+        fetchMock.mockResolvedValue(
+            mockFetchJsonResponse({
+                ok: true,
+                data: {
+                    status: "success",
+                    imported: 0,
+                    skipped: 2,
+                },
+            }),
+        );
+
+        const payload = {
+            attendanceDate: {
+                startDate: "01/01/2026",
+                endDate: "28/01/2026",
+            },
+            tablingDate: "28/01/2026 17:10:10",
+            workers: [],
+        };
+
+        await importAttendRecordTimesheet(payload, "skip");
+
+        expect(fetchMock).toHaveBeenCalledWith("/api/timesheets/import?mode=skip", {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+            },
+            body: JSON.stringify(payload),
         });
     });
 });

--- a/app/dashboard/timesheet/import/import-attend-record-timesheet.ts
+++ b/app/dashboard/timesheet/import/import-attend-record-timesheet.ts
@@ -1,12 +1,13 @@
+import type {
+    ImportAttendRecordResult,
+    ImportAttendRecordMode,
+} from "@/services/timesheet/import-attend-record-timesheet";
 import type { AttendRecordOutput } from "@/utils/payroll/parse-attendrecord";
 
 type ImportAttendRecordTimesheetResponse =
     | {
           ok: true;
-          data: {
-              imported: number;
-              errors?: string[];
-          };
+          data: ImportAttendRecordResult;
       }
     | {
           ok: false;
@@ -37,10 +38,12 @@ function stripHoursFromAttendRecordPayload(
 
 export async function importAttendRecordTimesheet(
     data: AttendRecordOutput,
-): Promise<{ imported: number; errors?: string[] } | { error: string }> {
+    mode?: ImportAttendRecordMode,
+): Promise<ImportAttendRecordResult | { error: string }> {
     try {
         const sanitizedData = stripHoursFromAttendRecordPayload(data);
-        const response = await fetch("/api/timesheets/import", {
+        const qs = mode != null ? `?mode=${encodeURIComponent(mode)}` : "";
+        const response = await fetch(`/api/timesheets/import${qs}`, {
             method: "POST",
             headers: {
                 "Content-Type": "application/json",

--- a/app/dashboard/timesheet/import/timesheet-import-client.test.tsx
+++ b/app/dashboard/timesheet/import/timesheet-import-client.test.tsx
@@ -151,7 +151,11 @@ describe("TimesheetImportClient", () => {
         };
 
         parseAttendRecordMock.mockReturnValue(parsedAttendRecord);
-        importAttendRecordTimesheetMock.mockResolvedValue({ imported: 2 });
+        importAttendRecordTimesheetMock.mockResolvedValue({
+            status: "success",
+            imported: 2,
+            skipped: 0,
+        });
 
         render(
             <TimesheetImportClient
@@ -200,30 +204,33 @@ describe("TimesheetImportClient", () => {
 
         await user.click(uploadButton);
 
-        expect(importAttendRecordTimesheetMock).toHaveBeenCalledWith({
-            attendanceDate: parsedAttendRecord.attendanceDate,
-            tablingDate: parsedAttendRecord.tablingDate,
-            workers: [
-                {
-                    userId: "",
-                    name: "Alice Tan",
-                    dates: [
-                        {
-                            dateIn: "01/01/2026",
-                            timeIn: "09:00",
-                            dateOut: "01/01/2026",
-                            timeOut: "17:00",
-                        },
-                        {
-                            dateIn: "02/01/2026",
-                            timeIn: "09:00",
-                            dateOut: "02/01/2026",
-                            timeOut: "17:00",
-                        },
-                    ],
-                },
-            ],
-        });
+        expect(importAttendRecordTimesheetMock).toHaveBeenCalledWith(
+            {
+                attendanceDate: parsedAttendRecord.attendanceDate,
+                tablingDate: parsedAttendRecord.tablingDate,
+                workers: [
+                    {
+                        userId: "",
+                        name: "Alice Tan",
+                        dates: [
+                            {
+                                dateIn: "01/01/2026",
+                                timeIn: "09:00",
+                                dateOut: "01/01/2026",
+                                timeOut: "17:00",
+                            },
+                            {
+                                dateIn: "02/01/2026",
+                                timeIn: "09:00",
+                                dateOut: "02/01/2026",
+                                timeOut: "17:00",
+                            },
+                        ],
+                    },
+                ],
+            },
+            undefined,
+        );
         expect(await screen.findByText("Imported 2 entries.")).toBeDefined();
         expect(screen.queryByText("attend-record.xls")).toBeNull();
     });
@@ -254,7 +261,9 @@ describe("TimesheetImportClient", () => {
 
         parseAttendRecordMock.mockReturnValue(parsedAttendRecord);
         importAttendRecordTimesheetMock.mockResolvedValue({
+            status: "success",
             imported: 0,
+            skipped: 0,
             errors: ["Unknown worker: Alice Tan"],
         });
 
@@ -381,6 +390,112 @@ describe("TimesheetImportClient", () => {
                 ),
         ).toBe(true);
         expect((uploadButton as HTMLButtonElement).disabled).toBe(false);
+    });
+
+    it("shows overlapping dates prompt and re-submits with skip mode", async () => {
+        const user = userEvent.setup();
+        const parsedAttendRecord: AttendRecordOutput = {
+            attendanceDate: {
+                startDate: "01/01/2026",
+                endDate: "01/01/2026",
+            },
+            tablingDate: "01/01/2026 17:00:00",
+            workers: [
+                {
+                    userId: "",
+                    name: "Alice Tan",
+                    dates: [
+                        {
+                            dateIn: "01/01/2026",
+                            timeIn: "09:00",
+                            dateOut: "01/01/2026",
+                            timeOut: "17:00",
+                        },
+                    ],
+                },
+            ],
+        };
+
+        parseAttendRecordMock.mockReturnValue(parsedAttendRecord);
+        importAttendRecordTimesheetMock
+            .mockResolvedValueOnce({
+                status: "confirmation_required",
+                overlaps: [
+                    {
+                        workerName: "Alice Tan",
+                        dateIn: "2026-01-01",
+                        existingCount: 1,
+                    },
+                ],
+            })
+            .mockResolvedValueOnce({
+                status: "success",
+                imported: 0,
+                skipped: 1,
+            });
+
+        render(
+            <TimesheetImportClient
+                workers={[
+                    {
+                        id: "worker-1",
+                        name: "Alice Tan",
+                        status: "Active",
+                    },
+                ]}
+            />,
+        );
+
+        await user.upload(
+            screen.getByLabelText(/Drag and drop or click to upload/i),
+            new File(["legacy attend record"], "attend-record.xls", {
+                type: "application/vnd.ms-excel",
+            }),
+        );
+
+        const uploadButton = await screen.findByRole("button", {
+            name: "Upload Timesheet",
+        });
+        await user.click(uploadButton);
+
+        expect(
+            await screen.findByText("Overlapping timesheet dates"),
+        ).toBeDefined();
+        expect((uploadButton as HTMLButtonElement).disabled).toBe(true);
+
+        await user.click(screen.getByRole("button", { name: "Skip duplicates" }));
+
+        const expectedPayload = {
+            attendanceDate: parsedAttendRecord.attendanceDate,
+            tablingDate: parsedAttendRecord.tablingDate,
+            workers: [
+                {
+                    userId: "",
+                    name: "Alice Tan",
+                    dates: [
+                        {
+                            dateIn: "01/01/2026",
+                            timeIn: "09:00",
+                            dateOut: "01/01/2026",
+                            timeOut: "17:00",
+                        },
+                    ],
+                },
+            ],
+        };
+        expect(importAttendRecordTimesheetMock).toHaveBeenNthCalledWith(
+            1,
+            expectedPayload,
+            undefined,
+        );
+        expect(importAttendRecordTimesheetMock).toHaveBeenNthCalledWith(
+            2,
+            expectedPayload,
+            "skip",
+        );
+        expect(
+            await screen.findByText(/No new entries imported. Skipped 1 duplicates/),
+        ).toBeDefined();
     });
 
     it("clears manual worker matches when uploading a different file", async () => {

--- a/app/dashboard/timesheet/import/timesheet-import-client.tsx
+++ b/app/dashboard/timesheet/import/timesheet-import-client.tsx
@@ -4,6 +4,7 @@ import * as React from "react";
 import * as XLSX from "xlsx";
 
 import { importAttendRecordTimesheet } from "./import-attend-record-timesheet";
+import type { OverlapEntry } from "@/services/timesheet/import-attend-record-timesheet";
 import { SelectSearch } from "@/components/ui/SelectSearch";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
@@ -25,6 +26,11 @@ import {
 } from "@/components/ui/table";
 import { Trash2, Upload } from "lucide-react";
 import { parseAttendRecord } from "@/utils/payroll/parse-attendrecord";
+import {
+    clockIntervalDurationMs,
+    formatDurationHm,
+    parseTimeForHours,
+} from "@/utils/payroll/payroll-utils";
 import type { AttendRecordOutput } from "@/utils/payroll/parse-attendrecord";
 import {
     resolveTimesheetImportWorkerMatches,
@@ -58,8 +64,8 @@ function hasMissingData(row: FlatRow): boolean {
     return (
         parseDate(row.dateIn) == null ||
         parseDate(row.dateOut) == null ||
-        parseTime(row.timeIn) == null ||
-        parseTime(row.timeOut) == null
+        parseTimeForHours(row.timeIn) == null ||
+        parseTimeForHours(row.timeOut) == null
     );
 }
 
@@ -117,52 +123,15 @@ function parseDate(dateStr: string): Date | null {
     return d;
 }
 
-/** Parse "HH:MM" to { h, m }. Returns null if invalid. */
-function parseTime(time: string): { h: number; m: number } | null {
-    const trimmed = time.trim();
-    if (!trimmed) return null;
-    const match = trimmed.match(/^(\d{1,2}):(\d{2})$/);
-    if (!match) return null;
-    const h = parseInt(match[1]!, 10);
-    const m = parseInt(match[2]!, 10);
-    if (h < 0 || h > 23 || m < 0 || m > 59) return null;
-    return { h, m };
-}
-
-/** Calculate working hours from dateIn+timeIn to dateOut+timeOut. Uses same validation as hasMissingData (parseDate/parseTime). Returns "Xh Ym" or "0h" when invalid. */
 function calcWorkingHours(
     dateIn: string,
     timeIn: string,
     dateOut: string,
     timeOut: string,
 ): string {
-    const dIn = parseDate(dateIn);
-    const dOut = parseDate(dateOut);
-    const tIn = parseTime(timeIn);
-    const tOut = parseTime(timeOut);
-    if (!dIn || !dOut || !tIn || !tOut) return "0h";
-    const start = new Date(
-        dIn.getFullYear(),
-        dIn.getMonth(),
-        dIn.getDate(),
-        tIn.h,
-        tIn.m,
+    return formatDurationHm(
+        clockIntervalDurationMs(dateIn, timeIn, dateOut, timeOut) ?? 0,
     );
-    const end = new Date(
-        dOut.getFullYear(),
-        dOut.getMonth(),
-        dOut.getDate(),
-        tOut.h,
-        tOut.m,
-    );
-    const diffMs = end.getTime() - start.getTime();
-    if (diffMs < 0) return "0h";
-    const totalMinutes = Math.floor(diffMs / (60 * 1000));
-    const h = Math.floor(totalMinutes / 60);
-    const m = totalMinutes % 60;
-    if (h > 0 && m > 0) return `${h}h ${m}m`;
-    if (h > 0) return `${h}h`;
-    return `${m}m`;
 }
 
 /** Enforce DD/MM/YYYY format as user types - digits only, auto-insert slashes */
@@ -264,8 +233,12 @@ export function TimesheetImportClient({
     const [error, setError] = React.useState<string | null>(null);
     const [submitResult, setSubmitResult] = React.useState<{
         imported?: number;
+        skipped?: number;
         errors?: string[];
     } | null>(null);
+    const [overlapResult, setOverlapResult] = React.useState<OverlapEntry[] | null>(
+        null,
+    );
     const [pending, setPending] = React.useState(false);
     const [manualWorkerMatches, setManualWorkerMatches] = React.useState<
         Record<string, string>
@@ -274,6 +247,7 @@ export function TimesheetImportClient({
     const handleParse = React.useCallback(async (file: File) => {
         setError(null);
         setSubmitResult(null);
+        setOverlapResult(null);
         setManualWorkerMatches({});
         try {
             const data = await file.arrayBuffer();
@@ -335,50 +309,67 @@ export function TimesheetImportClient({
         [],
     );
 
-    const handleSubmit = React.useCallback(async () => {
-        if (!parsedData || editableRows.length === 0) return;
-        setError(null);
-        setSubmitResult(null);
-        setPending(true);
-        try {
-            const workerMatchResult = resolveTimesheetImportWorkerMatches({
-                rows: editableRows,
-                workers,
-                manualMatchesByImportedName: manualWorkerMatches,
-            });
-            const resolvedWorkerNamesByImportedName = new Map(
-                workerMatchResult.groups
-                    .filter((group) => group.resolvedWorker != null)
-                    .map((group) => [
-                        group.importedName,
-                        group.resolvedWorker!.name,
-                    ]),
-            );
-            const dataToImport = editableRowsToAttendRecord(
-                editableRows,
-                {
-                    attendanceDate: parsedData.attendanceDate,
-                    tablingDate: parsedData.tablingDate,
-                },
-                resolvedWorkerNamesByImportedName,
-            );
-            const result = await importAttendRecordTimesheet(dataToImport);
-            if ("error" in result) {
-                setError(result.error);
-                return;
+    const handleSubmit = React.useCallback(
+        async (mode?: "skip" | "force") => {
+            if (!parsedData || editableRows.length === 0) return;
+            setError(null);
+            if (mode == null) {
+                setSubmitResult(null);
             }
-            setSubmitResult(result);
-            if (result.imported && result.imported > 0) {
-                setFile(null);
-                setParsedData(null);
-                setEditableRows([]);
+            setPending(true);
+            try {
+                const workerMatchResult = resolveTimesheetImportWorkerMatches({
+                    rows: editableRows,
+                    workers,
+                    manualMatchesByImportedName: manualWorkerMatches,
+                });
+                const resolvedWorkerNamesByImportedName = new Map(
+                    workerMatchResult.groups
+                        .filter((group) => group.resolvedWorker != null)
+                        .map((group) => [
+                            group.importedName,
+                            group.resolvedWorker!.name,
+                        ]),
+                );
+                const dataToImport = editableRowsToAttendRecord(
+                    editableRows,
+                    {
+                        attendanceDate: parsedData.attendanceDate,
+                        tablingDate: parsedData.tablingDate,
+                    },
+                    resolvedWorkerNamesByImportedName,
+                );
+                const result = await importAttendRecordTimesheet(
+                    dataToImport,
+                    mode,
+                );
+                if ("error" in result) {
+                    setError(result.error);
+                    return;
+                }
+                if (result.status === "confirmation_required") {
+                    setOverlapResult(result.overlaps);
+                    return;
+                }
+                setOverlapResult(null);
+                setSubmitResult({
+                    imported: result.imported,
+                    skipped: result.skipped,
+                    errors: result.errors,
+                });
+                if (result.imported > 0) {
+                    setFile(null);
+                    setParsedData(null);
+                    setEditableRows([]);
+                }
+            } catch (err) {
+                setError(err instanceof Error ? err.message : "Import failed");
+            } finally {
+                setPending(false);
             }
-        } catch (err) {
-            setError(err instanceof Error ? err.message : "Import failed");
-        } finally {
-            setPending(false);
-        }
-    }, [parsedData, editableRows, workers, manualWorkerMatches]);
+        },
+        [parsedData, editableRows, workers, manualWorkerMatches],
+    );
 
     const onDrop = React.useCallback(
         (e: React.DragEvent) => {
@@ -423,6 +414,7 @@ export function TimesheetImportClient({
         setEditableRows([]);
         setError(null);
         setSubmitResult(null);
+        setOverlapResult(null);
         setManualWorkerMatches({});
     }, []);
 
@@ -553,6 +545,73 @@ export function TimesheetImportClient({
                                             ),
                                         )}
                                     </ul>
+                                </div>
+                            )}
+                            {overlapResult != null && overlapResult.length > 0 && (
+                                <div className="rounded-md border border-amber-300 bg-amber-50 p-3 text-sm text-amber-900 dark:border-amber-900/60 dark:bg-amber-950/30 dark:text-amber-200">
+                                    <p className="font-medium">
+                                        Overlapping timesheet dates
+                                    </p>
+                                    <p className="mt-1">
+                                        {overlapResult.reduce(
+                                            (sum, o) => sum + o.existingCount,
+                                            0,
+                                        )}{" "}
+                                        entr
+                                        {overlapResult.reduce(
+                                            (sum, o) => sum + o.existingCount,
+                                            0,
+                                        ) !== 1
+                                            ? "ies"
+                                            : "y"}{" "}
+                                        already exist for{" "}
+                                        {
+                                            new Set(
+                                                overlapResult.map(
+                                                    (o) => o.workerName,
+                                                ),
+                                            ).size
+                                        }{" "}
+                                        worker
+                                        {new Set(
+                                            overlapResult.map(
+                                                (o) => o.workerName,
+                                            ),
+                                        ).size !== 1
+                                            ? "s"
+                                            : ""}{" "}
+                                        on the selected dates. Choose how to
+                                        proceed.
+                                    </p>
+                                    <ul className="mt-2 max-h-32 list-inside list-disc overflow-y-auto">
+                                        {overlapResult.map((o, idx) => (
+                                            <li key={`${o.workerName}-${o.dateIn}-${idx}`}>
+                                                {o.workerName} — {o.dateIn}{" "}
+                                                ({o.existingCount} existing)
+                                            </li>
+                                        ))}
+                                    </ul>
+                                    <div className="mt-3 flex flex-wrap gap-2">
+                                        <Button
+                                            type="button"
+                                            variant="outline"
+                                            size="sm"
+                                            disabled={pending}
+                                            onClick={() => {
+                                                void handleSubmit("skip");
+                                            }}>
+                                            Skip duplicates
+                                        </Button>
+                                        <Button
+                                            type="button"
+                                            size="sm"
+                                            disabled={pending}
+                                            onClick={() => {
+                                                void handleSubmit("force");
+                                            }}>
+                                            Import all anyway
+                                        </Button>
+                                    </div>
                                 </div>
                             )}
                             <div className="rounded-md border overflow-x-auto max-h-[70vh] overflow-y-auto">
@@ -755,7 +814,7 @@ export function TimesheetImportClient({
                                                                     formatted,
                                                                 );
                                                             }}
-                                                            className={`min-w-20 rounded px-2 py-1.5 outline-none focus:ring-2 focus:ring-ring focus:ring-inset ${parseTime(row.timeIn) == null ? "text-destructive" : ""}`}>
+                                                            className={`min-w-20 rounded px-2 py-1.5 outline-none focus:ring-2 focus:ring-ring focus:ring-inset ${parseTimeForHours(row.timeIn) == null ? "text-destructive" : ""}`}>
                                                             {row.timeIn}
                                                         </div>
                                                     </TableCell>
@@ -884,7 +943,7 @@ export function TimesheetImportClient({
                                                                     formatted,
                                                                 );
                                                             }}
-                                                            className={`min-w-20 rounded px-2 py-1.5 outline-none focus:ring-2 focus:ring-ring focus:ring-inset ${parseTime(row.timeOut) == null ? "text-destructive" : ""}`}>
+                                                            className={`min-w-20 rounded px-2 py-1.5 outline-none focus:ring-2 focus:ring-ring focus:ring-inset ${parseTimeForHours(row.timeOut) == null ? "text-destructive" : ""}`}>
                                                             {row.timeOut || "—"}
                                                         </div>
                                                     </TableCell>
@@ -939,6 +998,22 @@ export function TimesheetImportClient({
                                     <p className="text-emerald-600 dark:text-emerald-400">
                                         Imported {submitResult.imported}{" "}
                                         entries.
+                                        {submitResult.skipped != null &&
+                                            submitResult.skipped > 0 && (
+                                                <>
+                                                    {" "}
+                                                    Skipped{" "}
+                                                    {submitResult.skipped}{" "}
+                                                    duplicates.
+                                                </>
+                                            )}
+                                    </p>
+                                )}
+                            {submitResult.imported === 0 &&
+                                (submitResult.skipped ?? 0) > 0 && (
+                                    <p className="text-amber-600 dark:text-amber-400">
+                                        No new entries imported. Skipped{" "}
+                                        {submitResult.skipped} duplicates.
                                     </p>
                                 )}
                             {submitResult.errors &&
@@ -968,9 +1043,12 @@ export function TimesheetImportClient({
                                 totalEntries === 0 ||
                                 pending ||
                                 hasUnresolvedWorkerMatches ||
-                                editableRows.some(hasRowError)
+                                editableRows.some(hasRowError) ||
+                                overlapResult != null
                             }
-                            onClick={handleSubmit}>
+                            onClick={() => {
+                                void handleSubmit();
+                            }}>
                             {pending ? "Importing..." : "Upload Timesheet"}
                         </Button>
                     </div>

--- a/db/apply-custom-schema.ts
+++ b/db/apply-custom-schema.ts
@@ -59,6 +59,9 @@ export async function applyCustomSchemaArtifacts(
                 END IF;
             END
             $$;
+
+            CREATE UNIQUE INDEX IF NOT EXISTS timesheet_worker_date_time_in_uniq
+            ON "timesheet" ("worker_id", "date_in", "time_in");
         `),
     );
 }

--- a/services/timesheet/import-attend-record-timesheet.service.test.ts
+++ b/services/timesheet/import-attend-record-timesheet.service.test.ts
@@ -24,31 +24,89 @@ vi.mock("@/services/payroll/guided-monthly-workflow-activity", () => ({
 
 import { importAttendRecordTimesheet } from "@/services/timesheet/import-attend-record-timesheet";
 import { timesheetTable } from "@/db/tables/timesheetTable";
+import { workerTable } from "@/db/tables/workerTable";
 import {
     deepCloneJson,
     makeAttendRecordPayload,
     makeImportOperationalState,
 } from "@/test/factories/attendrecord";
 
+function makeInsertChainResult(rows: { workerId: string }[]) {
+    return {
+        onConflictDoNothing: vi.fn().mockReturnValue({
+            returning: vi.fn().mockResolvedValue(
+                rows.map((row, i) => ({
+                    id: `inserted-${i}`,
+                    workerId: row.workerId,
+                })),
+            ),
+        }),
+    };
+}
+
+function configureDefaultWorkersSelect() {
+    mocks.db.select.mockImplementation(() => ({
+        from: vi.fn((table: unknown) => {
+            if (table === timesheetTable) {
+                return {
+                    where: vi.fn().mockResolvedValue([]),
+                };
+            }
+            if (table === workerTable) {
+                return Promise.resolve([
+                    { id: "worker-1", name: "Worker One", status: "Active" },
+                    { id: "worker-2", name: "Worker Two", status: "Active" },
+                ]);
+            }
+            throw new Error("Unexpected table in select mock");
+        }),
+    }));
+}
+
 function configureStatefulImportDatabase(
     state: ReturnType<typeof makeImportOperationalState>,
 ) {
-    mocks.db.select.mockReturnValue({
-        from: vi.fn().mockResolvedValue(state.workers),
-    });
+    mocks.db.select.mockImplementation(() => ({
+        from: vi.fn((table: unknown) => {
+            if (table === timesheetTable) {
+                return {
+                    where: vi.fn().mockResolvedValue([]),
+                };
+            }
+            if (table === workerTable) {
+                return Promise.resolve(state.workers);
+            }
+            throw new Error("Unexpected table in select mock");
+        }),
+    }));
     mocks.db.insert.mockImplementation((table) => {
         if (table !== timesheetTable) {
             throw new Error("Timesheet import should only insert timesheet rows");
         }
 
         return {
-            values: vi.fn().mockImplementation(async (rows) => {
-                state.timesheets.push(
-                    ...rows.map((row: Record<string, unknown>, index: number) => ({
-                        id: `imported-timesheet-${index + 1}`,
-                        ...row,
-                    })),
-                );
+            values: vi.fn().mockImplementation((rows: Record<string, unknown>[]) => {
+                const baseLen = state.timesheets.length;
+                const inserted = rows.map((row, index: number) => ({
+                    id: `imported-timesheet-${baseLen + index + 1}`,
+                    workerId: row.workerId as string,
+                    dateIn: row.dateIn as string,
+                    timeIn: row.timeIn as string,
+                    dateOut: row.dateOut as string,
+                    timeOut: row.timeOut as string,
+                    status: "Timesheet Unpaid",
+                }));
+                return {
+                    onConflictDoNothing: vi.fn().mockReturnValue({
+                        returning: vi.fn().mockImplementation(async () => {
+                            state.timesheets.push(...inserted);
+                            return inserted.map((r) => ({
+                                id: r.id as string,
+                                workerId: r.workerId as string,
+                            }));
+                        }),
+                    }),
+                };
             }),
         };
     });
@@ -57,15 +115,12 @@ function configureStatefulImportDatabase(
 describe("services/timesheet/import-attend-record-timesheet", () => {
     beforeEach(() => {
         vi.clearAllMocks();
-        mocks.db.select.mockReturnValue({
-            from: vi.fn().mockResolvedValue([
-                { id: "worker-1", name: "Worker One", status: "Active" },
-                { id: "worker-2", name: "Worker Two", status: "Active" },
-            ]),
-        });
-        mocks.db.insert.mockReturnValue({
-            values: vi.fn().mockResolvedValue(undefined),
-        });
+        configureDefaultWorkersSelect();
+        mocks.db.insert.mockImplementation(() => ({
+            values: vi.fn().mockImplementation((rows: { workerId: string }[]) =>
+                makeInsertChainResult(rows),
+            ),
+        }));
         mocks.synchronizeWorkerDraftPayrolls.mockResolvedValue({ success: true });
     });
 
@@ -73,7 +128,9 @@ describe("services/timesheet/import-attend-record-timesheet", () => {
         await expect(
             importAttendRecordTimesheet(makeAttendRecordPayload()),
         ).resolves.toEqual({
+            status: "success",
             imported: 3,
+            skipped: 0,
             errors: undefined,
         });
 
@@ -108,23 +165,37 @@ describe("services/timesheet/import-attend-record-timesheet", () => {
         await expect(
             importAttendRecordTimesheet(makeAttendRecordPayload()),
         ).resolves.toEqual({
+            status: "success",
             imported: 3,
+            skipped: 0,
             errors: ["Failed to synchronize Draft payrolls"],
         });
     });
 
     it("returns a clear error when the import includes an inactive worker", async () => {
-        mocks.db.select.mockReturnValue({
-            from: vi.fn().mockResolvedValue([
-                { id: "worker-1", name: "Worker One", status: "Inactive" },
-                { id: "worker-2", name: "Worker Two", status: "Active" },
-            ]),
-        });
+        mocks.db.select.mockImplementation(() => ({
+            from: vi.fn((table: unknown) => {
+                if (table === timesheetTable) {
+                    return {
+                        where: vi.fn().mockResolvedValue([]),
+                    };
+                }
+                if (table === workerTable) {
+                    return Promise.resolve([
+                        { id: "worker-1", name: "Worker One", status: "Inactive" },
+                        { id: "worker-2", name: "Worker Two", status: "Active" },
+                    ]);
+                }
+                throw new Error("Unexpected table in select mock");
+            }),
+        }));
 
         await expect(
             importAttendRecordTimesheet(makeAttendRecordPayload()),
         ).resolves.toEqual({
+            status: "success",
             imported: 1,
+            skipped: 0,
             errors: [
                 "Cannot import timesheet for Worker One because worker status is Inactive",
             ],
@@ -170,7 +241,9 @@ describe("services/timesheet/import-attend-record-timesheet", () => {
                 ],
             }),
         ).resolves.toEqual({
+            status: "success",
             imported: 1,
+            skipped: 0,
             errors: undefined,
         });
 
@@ -229,7 +302,9 @@ describe("services/timesheet/import-attend-record-timesheet", () => {
                 ],
             }),
         ).resolves.toEqual({
+            status: "success",
             imported: 0,
+            skipped: 0,
             errors: [
                 'Unknown worker "Unknown Worker"',
                 "Invalid date for Worker One: not-a-date",
@@ -239,5 +314,126 @@ describe("services/timesheet/import-attend-record-timesheet", () => {
         expect(state).toEqual(preserved);
         expect(mocks.recordGuidedMonthlyWorkflowStepCompletion).not.toHaveBeenCalled();
         expect(mocks.synchronizeWorkerDraftPayrolls).not.toHaveBeenCalled();
+    });
+
+    it("returns confirmation_required when timesheets already exist for imported worker/date pairs", async () => {
+        mocks.db.select.mockImplementation(() => ({
+            from: vi.fn((table: unknown) => {
+                if (table === timesheetTable) {
+                    return {
+                        where: vi.fn().mockResolvedValue([
+                            {
+                                workerId: "worker-1",
+                                dateIn: "2026-01-01",
+                                timeIn: "08:00:00",
+                            },
+                        ]),
+                    };
+                }
+                if (table === workerTable) {
+                    return Promise.resolve([
+                        { id: "worker-1", name: "Worker One", status: "Active" },
+                    ]);
+                }
+                throw new Error("Unexpected table in select mock");
+            }),
+        }));
+
+        await expect(
+            importAttendRecordTimesheet({
+                attendanceDate: {
+                    startDate: "01/01/2026",
+                    endDate: "01/01/2026",
+                },
+                tablingDate: "01/01/2026 17:10:10",
+                workers: [
+                    {
+                        userId: "",
+                        name: "Worker One",
+                        dates: [
+                            {
+                                dateIn: "01/01/2026",
+                                timeIn: "09:00",
+                                dateOut: "01/01/2026",
+                                timeOut: "17:00",
+                            },
+                        ],
+                    },
+                ],
+            }),
+        ).resolves.toEqual({
+            status: "confirmation_required",
+            overlaps: [
+                {
+                    workerName: "Worker One",
+                    dateIn: "2026-01-01",
+                    existingCount: 1,
+                },
+            ],
+        });
+
+        expect(mocks.db.insert).not.toHaveBeenCalled();
+    });
+
+    it("skips overlapping worker/date rows when mode is skip", async () => {
+        mocks.db.select.mockImplementation(() => ({
+            from: vi.fn((table: unknown) => {
+                if (table === timesheetTable) {
+                    return {
+                        where: vi.fn().mockResolvedValue([
+                            {
+                                workerId: "worker-1",
+                                dateIn: "2026-01-01",
+                                timeIn: "08:00:00",
+                            },
+                        ]),
+                    };
+                }
+                if (table === workerTable) {
+                    return Promise.resolve([
+                        { id: "worker-1", name: "Worker One", status: "Active" },
+                    ]);
+                }
+                throw new Error("Unexpected table in select mock");
+            }),
+        }));
+
+        await expect(
+            importAttendRecordTimesheet(
+                {
+                    attendanceDate: {
+                        startDate: "01/01/2026",
+                        endDate: "02/01/2026",
+                    },
+                    tablingDate: "02/01/2026 17:10:10",
+                    workers: [
+                        {
+                            userId: "",
+                            name: "Worker One",
+                            dates: [
+                                {
+                                    dateIn: "01/01/2026",
+                                    timeIn: "09:00",
+                                    dateOut: "01/01/2026",
+                                    timeOut: "17:00",
+                                },
+                                {
+                                    dateIn: "02/01/2026",
+                                    timeIn: "09:00",
+                                    dateOut: "02/01/2026",
+                                    timeOut: "17:00",
+                                },
+                            ],
+                        },
+                    ],
+                },
+                { mode: "skip" },
+            ),
+        ).resolves.toEqual({
+            status: "success",
+            imported: 1,
+            skipped: 1,
+            errors: undefined,
+        });
     });
 });

--- a/services/timesheet/import-attend-record-timesheet.ts
+++ b/services/timesheet/import-attend-record-timesheet.ts
@@ -1,3 +1,5 @@
+import { and, eq, or } from "drizzle-orm";
+
 import { timesheetEntryFormSchema } from "@/db/schemas/timesheet-entry";
 import { db } from "@/lib/db";
 import { workerTable } from "@/db/tables/workerTable";
@@ -6,6 +8,26 @@ import { synchronizeWorkerDraftPayrolls } from "@/services/payroll/synchronize-w
 import { recordGuidedMonthlyWorkflowStepCompletion } from "@/services/payroll/guided-monthly-workflow-activity";
 import { assertWorkerEligibleForTimesheet } from "@/services/worker/assert-worker-eligible-for-timesheet";
 import type { AttendRecordOutput } from "@/utils/payroll/parse-attendrecord";
+
+export type ImportAttendRecordMode = "skip" | "force";
+
+export type OverlapEntry = {
+    workerName: string;
+    dateIn: string;
+    existingCount: number;
+};
+
+export type ImportAttendRecordResult =
+    | {
+          status: "success";
+          imported: number;
+          skipped: number;
+          errors?: string[];
+      }
+    | {
+          status: "confirmation_required";
+          overlaps: OverlapEntry[];
+      };
 
 function toTimeString(val: string): string {
     const s = String(val).trim();
@@ -30,7 +52,22 @@ function ddMmYyyyToIso(val: string): string {
     return Number.isNaN(parsed.getTime()) ? "" : date;
 }
 
-export async function importAttendRecordTimesheet(data: AttendRecordOutput) {
+function pairsWhereClause(
+    pairs: { workerId: string; dateIn: string }[],
+) {
+    if (pairs.length === 0) {
+        return undefined;
+    }
+    const clauses = pairs.map((p) =>
+        and(eq(timesheetTable.workerId, p.workerId), eq(timesheetTable.dateIn, p.dateIn)),
+    );
+    return clauses.length === 1 ? clauses[0]! : or(...clauses);
+}
+
+export async function importAttendRecordTimesheet(
+    data: AttendRecordOutput,
+    options?: { mode?: ImportAttendRecordMode },
+): Promise<ImportAttendRecordResult> {
     const workerNames = await db
         .select({
             id: workerTable.id,
@@ -111,9 +148,103 @@ export async function importAttendRecordTimesheet(data: AttendRecordOutput) {
         }
     }
 
-    if (toInsert.length > 0) {
-        await db.insert(timesheetTable).values(toInsert);
+    if (toInsert.length === 0) {
+        return {
+            status: "success",
+            imported: 0,
+            skipped: 0,
+            errors: errors.length > 0 ? errors : undefined,
+        };
+    }
 
+    const pairKey = (workerId: string, dateIn: string) => `${workerId}|${dateIn}`;
+    const uniquePairsMap = new Map<string, { workerId: string; dateIn: string }>();
+    for (const row of toInsert) {
+        const key = pairKey(row.workerId, row.dateIn);
+        if (!uniquePairsMap.has(key)) {
+            uniquePairsMap.set(key, { workerId: row.workerId, dateIn: row.dateIn });
+        }
+    }
+    const uniquePairs = [...uniquePairsMap.values()];
+
+    const pairsClause = pairsWhereClause(uniquePairs);
+    const existing = pairsClause
+        ? await db
+              .select({
+                  workerId: timesheetTable.workerId,
+                  dateIn: timesheetTable.dateIn,
+                  timeIn: timesheetTable.timeIn,
+              })
+              .from(timesheetTable)
+              .where(pairsClause)
+        : [];
+
+    if (existing.length > 0 && options?.mode == null) {
+        const counts = new Map<string, number>();
+        for (const row of existing) {
+            const key = pairKey(row.workerId, String(row.dateIn));
+            counts.set(key, (counts.get(key) ?? 0) + 1);
+        }
+        const overlaps: OverlapEntry[] = [];
+        for (const [key, existingCount] of counts) {
+            const [workerId, dateIn] = key.split("|");
+            const worker = workerNames.find((w) => w.id === workerId);
+            overlaps.push({
+                workerName: worker?.name ?? workerId,
+                dateIn,
+                existingCount,
+            });
+        }
+        overlaps.sort((a, b) => {
+            const byName = a.workerName.localeCompare(b.workerName);
+            if (byName !== 0) return byName;
+            return a.dateIn.localeCompare(b.dateIn);
+        });
+        return {
+            status: "confirmation_required",
+            overlaps,
+        };
+    }
+
+    const overlappingPairKeys = new Set(
+        existing.map((row) => pairKey(row.workerId, String(row.dateIn))),
+    );
+    const rowsToInsert =
+        options?.mode === "skip"
+            ? toInsert.filter((row) => !overlappingPairKeys.has(pairKey(row.workerId, row.dateIn)))
+            : toInsert;
+
+    const pairFilteredSkipped = toInsert.length - rowsToInsert.length;
+
+    if (rowsToInsert.length === 0) {
+        return {
+            status: "success",
+            imported: 0,
+            skipped: pairFilteredSkipped,
+            errors: errors.length > 0 ? errors : undefined,
+        };
+    }
+
+    const insertedRows = await db
+        .insert(timesheetTable)
+        .values(rowsToInsert)
+        .onConflictDoNothing({
+            target: [
+                timesheetTable.workerId,
+                timesheetTable.dateIn,
+                timesheetTable.timeIn,
+            ],
+        })
+        .returning({
+            id: timesheetTable.id,
+            workerId: timesheetTable.workerId,
+        });
+
+    const imported = insertedRows.length;
+    const dbLevelSkipped = rowsToInsert.length - imported;
+    const skipped = pairFilteredSkipped + dbLevelSkipped;
+
+    if (imported > 0) {
         try {
             await recordGuidedMonthlyWorkflowStepCompletion({
                 stepId: "timesheet_import",
@@ -125,12 +256,16 @@ export async function importAttendRecordTimesheet(data: AttendRecordOutput) {
             );
         }
 
-        const affectedWorkerIds = [...new Set(toInsert.map((row) => row.workerId))];
+        const affectedWorkerIds = [
+            ...new Set(insertedRows.map((row) => row.workerId)),
+        ];
         for (const workerId of affectedWorkerIds) {
             const sync = await synchronizeWorkerDraftPayrolls({ workerId });
             if ("error" in sync) {
                 return {
-                    imported: toInsert.length,
+                    status: "success",
+                    imported,
+                    skipped,
                     errors: [...errors, sync.error],
                 };
             }
@@ -138,7 +273,9 @@ export async function importAttendRecordTimesheet(data: AttendRecordOutput) {
     }
 
     return {
-        imported: toInsert.length,
+        status: "success",
+        imported,
+        skipped,
         errors: errors.length > 0 ? errors : undefined,
     };
 }

--- a/utils/payroll/payroll-utils.ts
+++ b/utils/payroll/payroll-utils.ts
@@ -64,7 +64,7 @@ function parseDateForHours(dateStr: string): Date | null {
 }
 
 /** Parse time string (HH:MM or HH:MM:SS) to { h, m }. Returns null if invalid. */
-function parseTimeForHours(timeStr: string): { h: number; m: number } | null {
+export function parseTimeForHours(timeStr: string): { h: number; m: number } | null {
     const trimmed = String(timeStr).trim();
     if (!trimmed) return null;
     const match = trimmed.match(/^(\d{1,2}):(\d{2})(?::(\d{2}))?$/);
@@ -75,7 +75,7 @@ function parseTimeForHours(timeStr: string): { h: number; m: number } | null {
     return { h, m };
 }
 
-function clockIntervalDurationMs(
+export function clockIntervalDurationMs(
     dateIn: string,
     timeIn: string,
     dateOut: string,
@@ -101,6 +101,20 @@ function clockIntervalDurationMs(
         tOut.m,
     );
     return end.getTime() - start.getTime();
+}
+
+/** Formats a millisecond duration as whole hours, or hours + minutes (e.g. `8h`, `7h 30m`). */
+export function formatDurationHm(durationMs: number): string {
+    if (!Number.isFinite(durationMs) || durationMs <= 0) {
+        return "0h";
+    }
+    const totalMinutes = Math.floor(durationMs / (60 * 1000));
+    const hours = Math.floor(totalMinutes / 60);
+    const minutes = totalMinutes % 60;
+    if (minutes === 0) {
+        return `${hours}h`;
+    }
+    return `${hours}h ${minutes}m`;
 }
 
 /** True when clock-out is strictly after clock-in (matches {@link calculateHoursFromDateTimes} positive duration). */


### PR DESCRIPTION
## Summary

Adds duplicate detection and confirmation for AttendRecord-style timesheet imports.

### Database
- Unique index on `(worker_id, date_in, time_in)` via custom schema (run `npm run db:migrate`).

### Backend
- `importAttendRecordTimesheet` queries existing rows for the same worker + date; without `mode`, returns `confirmation_required` with overlap details.
- `mode=skip`: insert only rows for worker/dates that are not already present.
- `mode=force`: insert all rows; exact duplicate punches absorbed via `onConflictDoNothing`.

### API
- `POST /api/timesheets/import?mode=skip|force` (optional).

### UI
- Amber banner with **Skip duplicates** / **Import all anyway**; success message includes skipped count.

### Fix
- Export `clockIntervalDurationMs`, `parseTimeForHours`, and `formatDurationHm` from `payroll-utils` for the import client (Turbopack build).

## Commits
- `d7a54aa` feat(timesheet): duplicate guard on AttendRecord import
- `3be12e3` fix(payroll): export duration helpers for timesheet import UI


Made with [Cursor](https://cursor.com)