### PR TITLE
refactor: dedupe clone families (draft refresh, payroll commands, worker UI)

### DIFF
--- a/app/dashboard/_shared/dashboard-year-window.ts
+++ b/app/dashboard/_shared/dashboard-year-window.ts
@@ -1,0 +1,15 @@
+import { sql, type Column } from "drizzle-orm";
+
+/** Last five calendar years ending at `now`, used by dashboard aggregate queries. */
+export function dashboardYearWindow(now = new Date()) {
+    const maxYear = now.getFullYear();
+    const minYear = maxYear - 4;
+    const yearOptions = Array.from({ length: 5 }, (_, i) => maxYear - i);
+    return { maxYear, minYear, yearOptions };
+}
+
+export function yearMonthSqlFromColumn(column: Column) {
+    const yearExpr = sql<number>`extract(year from ${column})::int`;
+    const monthExpr = sql<number>`extract(month from ${column})::int`;
+    return { yearExpr, monthExpr };
+}

--- a/app/dashboard/_shared/payroll-aggregate-base.ts
+++ b/app/dashboard/_shared/payroll-aggregate-base.ts
@@ -6,14 +6,16 @@ import { payrollTable } from "@/db/tables/payrollTable";
 import { payrollVoucherTable } from "@/db/tables/payrollVoucherTable";
 import { workerTable } from "@/db/tables/workerTable";
 import {
-    payrollDashboardYearWindow,
-    payrollPeriodEndYearMonthExtract,
-    settledPayrollOverlappingYearsWhere,
-} from "@/services/payroll/monthly-dashboard-aggregation";
+    dashboardYearWindow,
+    yearMonthSqlFromColumn,
+} from "@/app/dashboard/_shared/dashboard-year-window";
+import { settledPayrollOverlappingYearsWhere } from "@/services/payroll/monthly-dashboard-aggregation";
 
 export function payrollDashboardAggregateContext() {
-    const { maxYear, minYear, yearOptions } = payrollDashboardYearWindow();
-    const { yearExpr, monthExpr } = payrollPeriodEndYearMonthExtract();
+    const { maxYear, minYear, yearOptions } = dashboardYearWindow();
+    const { yearExpr, monthExpr } = yearMonthSqlFromColumn(
+        payrollTable.periodEnd,
+    );
     return { maxYear, minYear, yearOptions, yearExpr, monthExpr };
 }
 

--- a/app/dashboard/advance/get-advance-monthly-repayment-aggregates.ts
+++ b/app/dashboard/advance/get-advance-monthly-repayment-aggregates.ts
@@ -5,15 +5,17 @@ import { advanceRequestTable } from "@/db/tables/advanceRequestTable";
 import { advanceTable } from "@/db/tables/advanceTable";
 import { employmentTable } from "@/db/tables/employmentTable";
 import { workerTable } from "@/db/tables/workerTable";
+import {
+    dashboardYearWindow,
+    yearMonthSqlFromColumn,
+} from "@/app/dashboard/_shared/dashboard-year-window";
 import type { MonthlyWorkerAmountAggregatesPayload } from "@/types/monthly-worker-amount-aggregates";
 
 export async function getAdvanceMonthlyRepaymentAggregates(): Promise<MonthlyWorkerAmountAggregatesPayload> {
-    const maxYear = new Date().getFullYear();
-    const minYear = maxYear - 4;
-    const yearOptions = Array.from({ length: 5 }, (_, i) => maxYear - i);
-
-    const yearExpr = sql<number>`extract(year from ${advanceTable.repaymentDate})::int`;
-    const monthExpr = sql<number>`extract(month from ${advanceTable.repaymentDate})::int`;
+    const { maxYear, minYear, yearOptions } = dashboardYearWindow();
+    const { yearExpr, monthExpr } = yearMonthSqlFromColumn(
+        advanceTable.repaymentDate,
+    );
 
     const raw = await db
         .select({

--- a/app/dashboard/payroll/selection-dialogs.test.tsx
+++ b/app/dashboard/payroll/selection-dialogs.test.tsx
@@ -199,30 +199,33 @@ describe("Payroll selection panels", () => {
         expect(mocks.push).toHaveBeenCalledWith("/dashboard/payroll/all");
     });
 
-    it("shows settling then generating in the dialog when settling drafts", async () => {
+    it("disables the button and navigates after settling completes", async () => {
         const user = userEvent.setup();
         let resolveSettle!: (value: unknown) => void;
         const settlePromise = new Promise((resolve) => {
             resolveSettle = resolve;
         });
-        let resolveZip!: (value: { ok: true }) => void;
-        const zipPromise = new Promise<{ ok: true }>((resolve) => {
-            resolveZip = resolve;
-        });
         mocks.settleDraftPayrolls.mockImplementationOnce(() => settlePromise);
-        mocks.streamPayrollZipFromApi.mockImplementationOnce(() => zipPromise);
         mocks.fetchSettlementCandidates.mockResolvedValue([payrollRow]);
 
         render(<SettleDraftPayrollsPanel />);
 
         expect(await screen.findByText("Alice")).toBeTruthy();
-        const clickDone = user.click(
+        await user.click(
             screen.getByRole("button", { name: "Settle selected (1)" }),
         );
 
-        expect(
-            await screen.findByText("Settling payrolls…"),
-        ).toBeTruthy();
+        await waitFor(() => {
+            expect(mocks.settleDraftPayrolls).toHaveBeenCalledWith([
+                "payroll-1",
+            ]);
+        });
+
+        await waitFor(() => {
+            expect(
+                screen.getByRole("button", { name: "Settling..." }),
+            ).toBeTruthy();
+        });
 
         resolveSettle({
             success: true,
@@ -231,19 +234,9 @@ describe("Payroll selection panels", () => {
         });
 
         await waitFor(() => {
-            expect(
-                screen.getByText("Generating PDFs and building ZIP…"),
-            ).toBeTruthy();
+            expect(mocks.push).toHaveBeenCalledWith("/dashboard/payroll/all");
         });
-
-        resolveZip({ ok: true });
-        await clickDone;
-        await waitFor(() => {
-            expect(
-                screen.queryByRole("dialog", { name: "Preparing download" }),
-            ).toBeNull();
-        });
-        expect(mocks.push).toHaveBeenCalledWith("/dashboard/payroll/all");
+        expect(mocks.streamPayrollZipFromApi).not.toHaveBeenCalled();
     });
 
     it("shows determinate ZIP progress after stream progress events", async () => {
@@ -259,18 +252,14 @@ describe("Payroll selection panels", () => {
                 }) => void,
             ) =>
                 new Promise<{ ok: true }>((resolve) => {
-                    setTimeout(() => {
-                        onProgress({ type: "meta", n: 2 });
-                        setTimeout(() => {
-                            onProgress({
-                                type: "progress",
-                                i: 1,
-                                n: 2,
-                                workerName: "Alice",
-                            });
-                            setTimeout(() => resolve({ ok: true }), 0);
-                        }, 0);
-                    }, 0);
+                    onProgress({ type: "meta", n: 2 });
+                    onProgress({
+                        type: "progress",
+                        i: 1,
+                        n: 2,
+                        workerName: "Alice",
+                    });
+                    setTimeout(() => resolve({ ok: true }), 30);
                 }),
         );
         mocks.fetchPayrollDownloadSelection.mockResolvedValue([payrollRow]);
@@ -286,7 +275,7 @@ describe("Payroll selection panels", () => {
 
         await waitFor(() => {
             expect(
-                screen.getByText("1 of 2 files finished processing"),
+                screen.getByText(/1 of 2 files finished processing/),
             ).toBeTruthy();
         });
         await waitFor(() => {

--- a/app/dashboard/timesheet/get-timesheet-monthly-hours-aggregates.ts
+++ b/app/dashboard/timesheet/get-timesheet-monthly-hours-aggregates.ts
@@ -4,18 +4,17 @@ import { db } from "@/lib/db";
 import { employmentTable } from "@/db/tables/employmentTable";
 import { timesheetTable } from "@/db/tables/timesheetTable";
 import { workerTable } from "@/db/tables/workerTable";
-import type {
-    TimesheetMonthlyHoursAggregateRow,
-    TimesheetMonthlyHoursAggregatesPayload,
-} from "@/types/timesheet-monthly-hours-aggregates";
+import {
+    dashboardYearWindow,
+    yearMonthSqlFromColumn,
+} from "@/app/dashboard/_shared/dashboard-year-window";
+import type { TimesheetMonthlyHoursAggregatesPayload } from "@/types/timesheet-monthly-hours-aggregates";
 
 export async function getTimesheetMonthlyHoursAggregates(): Promise<TimesheetMonthlyHoursAggregatesPayload> {
-    const maxYear = new Date().getFullYear();
-    const minYear = maxYear - 4;
-    const yearOptions = Array.from({ length: 5 }, (_, i) => maxYear - i);
-
-    const yearExpr = sql<number>`extract(year from ${timesheetTable.dateIn})::int`;
-    const monthExpr = sql<number>`extract(month from ${timesheetTable.dateIn})::int`;
+    const { maxYear, minYear, yearOptions } = dashboardYearWindow();
+    const { yearExpr, monthExpr } = yearMonthSqlFromColumn(
+        timesheetTable.dateIn,
+    );
 
     const raw = await db
         .select({

--- a/app/dashboard/worker/segmented-two-choice-field.tsx
+++ b/app/dashboard/worker/segmented-two-choice-field.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import * as React from "react";
+import {
+    Controller,
+    type Control,
+    type FieldPath,
+    type FieldValues,
+} from "react-hook-form";
+
+import { Field, FieldError, FieldLabel } from "@/components/ui/field";
+import { cn } from "@/lib/utils";
+
+export type SegmentedTwoChoiceOption<TValue extends string> = {
+    value: TValue;
+    label: string;
+    /** Tailwind classes when this option is selected */
+    activeClassName: string;
+    /** Hover classes when another option is selected (inactive state) */
+    inactiveHoverClassName: string;
+};
+
+type SegmentedTwoChoiceFieldProps<
+    TFieldValues extends FieldValues,
+    TValue extends string,
+> = {
+    control: Control<TFieldValues>;
+    name: FieldPath<TFieldValues>;
+    label: React.ReactNode;
+    icon?: React.ReactNode;
+    disabled?: boolean;
+    options: readonly [
+        SegmentedTwoChoiceOption<TValue>,
+        SegmentedTwoChoiceOption<TValue>,
+    ];
+    ariaLabel: string;
+};
+
+export function SegmentedTwoChoiceField<
+    TFieldValues extends FieldValues,
+    TValue extends string,
+>(props: SegmentedTwoChoiceFieldProps<TFieldValues, TValue>) {
+    const { control, name, label, icon, disabled, options, ariaLabel } = props;
+
+    return (
+        <Controller
+            name={name}
+            control={control}
+            render={({ field, fieldState }) => {
+                const selected = field.value as TValue;
+
+                return (
+                    <Field data-invalid={fieldState.invalid} className="space-y-2">
+                        <FieldLabel>
+                            <span className="flex items-center gap-2">
+                                {icon}
+                                {label}
+                            </span>
+                        </FieldLabel>
+                        <div
+                            role="group"
+                            aria-label={ariaLabel}
+                            className="flex gap-2">
+                            {options.map((option) => {
+                                const isActive = selected === option.value;
+
+                                return (
+                                    <button
+                                        key={option.value}
+                                        type="button"
+                                        disabled={disabled}
+                                        aria-pressed={isActive}
+                                        onClick={() =>
+                                            field.onChange(option.value as typeof field.value)
+                                        }
+                                        className={cn(
+                                            "flex-1 rounded-lg border-2 px-4 py-3 text-sm font-medium transition-colors",
+                                            isActive
+                                                ? option.activeClassName
+                                                : cn(
+                                                      "border-input bg-muted/50 text-muted-foreground",
+                                                      option.inactiveHoverClassName,
+                                                  ),
+                                            disabled &&
+                                                "cursor-not-allowed opacity-50",
+                                        )}>
+                                        {option.label}
+                                    </button>
+                                );
+                            })}
+                        </div>
+                        {fieldState.invalid && (
+                            <FieldError errors={[fieldState.error]} />
+                        )}
+                    </Field>
+                );
+            }}
+        />
+    );
+}

--- a/app/dashboard/worker/worker-form.tsx
+++ b/app/dashboard/worker/worker-form.tsx
@@ -72,6 +72,45 @@ import {
 } from "@/types/status";
 import { formatEnGbDmyNumericFromCalendar } from "@/utils/time/intl-en-gb";
 import { createWorker, updateWorker } from "./actions";
+import { SegmentedTwoChoiceField } from "./segmented-two-choice-field";
+
+const EMPLOYMENT_TYPE_SEGMENT_OPTIONS = [
+    {
+        value: "Full Time" as const,
+        label: "Full Time",
+        activeClassName:
+            "border-emerald-500 bg-emerald-50 text-emerald-800 dark:bg-emerald-500/20 dark:text-emerald-300 dark:border-emerald-500/50",
+        inactiveHoverClassName:
+            "hover:border-emerald-300 hover:bg-emerald-50/50 dark:hover:border-emerald-500/30 dark:hover:bg-emerald-500/10",
+    },
+    {
+        value: "Part Time" as const,
+        label: "Part Time",
+        activeClassName:
+            "border-sky-500 bg-sky-50 text-sky-800 dark:bg-sky-500/20 dark:text-sky-300 dark:border-sky-500/50",
+        inactiveHoverClassName:
+            "hover:border-sky-300 hover:bg-sky-50/50 dark:hover:border-sky-500/30 dark:hover:bg-sky-500/10",
+    },
+] as const;
+
+const EMPLOYMENT_ARRANGEMENT_SEGMENT_OPTIONS = [
+    {
+        value: "Foreign Worker" as const,
+        label: "Foreign Worker",
+        activeClassName:
+            "border-blue-500 bg-blue-50 text-blue-800 dark:bg-blue-500/20 dark:text-blue-300 dark:border-blue-500/50",
+        inactiveHoverClassName:
+            "hover:border-blue-300 hover:bg-blue-50/50 dark:hover:border-blue-500/30 dark:hover:bg-blue-500/10",
+    },
+    {
+        value: "Local Worker" as const,
+        label: "Local Worker",
+        activeClassName:
+            "border-amber-500 bg-amber-50 text-amber-800 dark:bg-amber-500/20 dark:text-amber-300 dark:border-amber-500/50",
+        inactiveHoverClassName:
+            "hover:border-amber-300 hover:bg-amber-50/50 dark:hover:border-amber-500/30 dark:hover:bg-amber-500/10",
+    },
+] as const;
 
 function optionalNumberString(n: number | null | undefined): string {
     if (n == null || Number.isNaN(n)) return "";
@@ -548,141 +587,25 @@ export function WorkerForm({ worker, disabled = false }: WorkerFormProps) {
                         </div>
 
                         <div className="grid gap-4 md:grid-cols-2">
-                            <Controller
+                            <SegmentedTwoChoiceField
+                                control={form.control}
                                 name="employmentType"
-                                control={form.control}
-                                render={({ field, fieldState }) => (
-                                    <Field
-                                        data-invalid={fieldState.invalid}
-                                        className="space-y-2">
-                                        <FieldLabel>
-                                            <span className="flex items-center gap-2">
-                                                <Briefcase className="size-4" />
-                                                Employment Type
-                                            </span>
-                                        </FieldLabel>
-                                        <div
-                                            role="group"
-                                            aria-label="Employment type"
-                                            className="flex gap-2">
-                                            <button
-                                                type="button"
-                                                disabled={disabled}
-                                                aria-pressed={
-                                                    field.value === "Full Time"
-                                                }
-                                                onClick={() =>
-                                                    field.onChange("Full Time")
-                                                }
-                                                className={cn(
-                                                    "flex-1 rounded-lg border-2 px-4 py-3 text-sm font-medium transition-colors",
-                                                    field.value === "Full Time"
-                                                        ? "border-emerald-500 bg-emerald-50 text-emerald-800 dark:bg-emerald-500/20 dark:text-emerald-300 dark:border-emerald-500/50"
-                                                        : "border-input bg-muted/50 text-muted-foreground hover:border-emerald-300 hover:bg-emerald-50/50 dark:hover:border-emerald-500/30 dark:hover:bg-emerald-500/10",
-                                                    disabled &&
-                                                        "cursor-not-allowed opacity-50",
-                                                )}>
-                                                Full Time
-                                            </button>
-                                            <button
-                                                type="button"
-                                                disabled={disabled}
-                                                aria-pressed={
-                                                    field.value === "Part Time"
-                                                }
-                                                onClick={() =>
-                                                    field.onChange("Part Time")
-                                                }
-                                                className={cn(
-                                                    "flex-1 rounded-lg border-2 px-4 py-3 text-sm font-medium transition-colors",
-                                                    field.value === "Part Time"
-                                                        ? "border-sky-500 bg-sky-50 text-sky-800 dark:bg-sky-500/20 dark:text-sky-300 dark:border-sky-500/50"
-                                                        : "border-input bg-muted/50 text-muted-foreground hover:border-sky-300 hover:bg-sky-50/50 dark:hover:border-sky-500/30 dark:hover:bg-sky-500/10",
-                                                    disabled &&
-                                                        "cursor-not-allowed opacity-50",
-                                                )}>
-                                                Part Time
-                                            </button>
-                                        </div>
-                                        {fieldState.invalid && (
-                                            <FieldError
-                                                errors={[fieldState.error]}
-                                            />
-                                        )}
-                                    </Field>
-                                )}
+                                label="Employment Type"
+                                icon={<Briefcase className="size-4" />}
+                                disabled={disabled}
+                                options={EMPLOYMENT_TYPE_SEGMENT_OPTIONS}
+                                ariaLabel="Employment type"
                             />
-                            <Controller
-                                name="employmentArrangement"
+                            <SegmentedTwoChoiceField
                                 control={form.control}
-                                render={({ field, fieldState }) => (
-                                    <Field
-                                        data-invalid={fieldState.invalid}
-                                        className="space-y-2">
-                                        <FieldLabel>
-                                            <span className="flex items-center gap-2">
-                                                <Users className="size-4" />
-                                                Employment Arrangement
-                                            </span>
-                                        </FieldLabel>
-                                        <div
-                                            role="group"
-                                            aria-label="Employment arrangement"
-                                            className="flex gap-2">
-                                            <button
-                                                type="button"
-                                                disabled={disabled}
-                                                aria-pressed={
-                                                    field.value ===
-                                                    "Foreign Worker"
-                                                }
-                                                onClick={() =>
-                                                    field.onChange(
-                                                        "Foreign Worker",
-                                                    )
-                                                }
-                                                className={cn(
-                                                    "flex-1 rounded-lg border-2 px-4 py-3 text-sm font-medium transition-colors",
-                                                    field.value ===
-                                                        "Foreign Worker"
-                                                        ? "border-blue-500 bg-blue-50 text-blue-800 dark:bg-blue-500/20 dark:text-blue-300 dark:border-blue-500/50"
-                                                        : "border-input bg-muted/50 text-muted-foreground hover:border-blue-300 hover:bg-blue-50/50 dark:hover:border-blue-500/30 dark:hover:bg-blue-500/10",
-                                                    disabled &&
-                                                        "cursor-not-allowed opacity-50",
-                                                )}>
-                                                Foreign Worker
-                                            </button>
-                                            <button
-                                                type="button"
-                                                disabled={disabled}
-                                                aria-pressed={
-                                                    field.value ===
-                                                    "Local Worker"
-                                                }
-                                                onClick={() =>
-                                                    field.onChange(
-                                                        "Local Worker",
-                                                    )
-                                                }
-                                                className={cn(
-                                                    "flex-1 rounded-lg border-2 px-4 py-3 text-sm font-medium transition-colors",
-                                                    field.value ===
-                                                        "Local Worker"
-                                                        ? "border-amber-500 bg-amber-50 text-amber-800 dark:bg-amber-500/20 dark:text-amber-300 dark:border-amber-500/50"
-                                                        : "border-input bg-muted/50 text-muted-foreground hover:border-amber-300 hover:bg-amber-50/50 dark:hover:border-amber-500/30 dark:hover:bg-amber-500/10",
-                                                    disabled &&
-                                                        "cursor-not-allowed opacity-50",
-                                                )}>
-                                                Local Worker
-                                            </button>
-                                        </div>
-                                        {fieldState.invalid && (
-                                            <FieldError
-                                                errors={[fieldState.error]}
-                                            />
-                                        )}
-                                    </Field>
-                                )}
+                                name="employmentArrangement"
+                                label="Employment Arrangement"
+                                icon={<Users className="size-4" />}
+                                disabled={disabled}
+                                options={
+                                    EMPLOYMENT_ARRANGEMENT_SEGMENT_OPTIONS
+                                }
+                                ariaLabel="Employment arrangement"
                             />
                         </div>
 

--- a/services/payroll/_shared/advance-repayment-window.ts
+++ b/services/payroll/_shared/advance-repayment-window.ts
@@ -1,0 +1,21 @@
+import { and, eq, gte, lte } from "drizzle-orm";
+
+import { advanceRequestTable } from "@/db/tables/advanceRequestTable";
+import { advanceTable } from "@/db/tables/advanceTable";
+
+export type AdvanceRepaymentPayrollWindow = {
+    workerId: string;
+    periodStart: string;
+    periodEnd: string;
+};
+
+/** Shared join filter: advances repaid within a payroll period window for a worker. */
+export function advanceRepaymentInPayrollWindowWhere(
+    payroll: AdvanceRepaymentPayrollWindow,
+) {
+    return and(
+        eq(advanceRequestTable.workerId, payroll.workerId),
+        gte(advanceTable.repaymentDate, payroll.periodStart),
+        lte(advanceTable.repaymentDate, payroll.periodEnd),
+    );
+}

--- a/services/payroll/_shared/query-payroll-selection-rows.ts
+++ b/services/payroll/_shared/query-payroll-selection-rows.ts
@@ -1,0 +1,61 @@
+import { asc, eq } from "drizzle-orm";
+
+import { payrollTable, type SelectPayroll } from "@/db/tables/payrollTable";
+import { payrollVoucherTable } from "@/db/tables/payrollVoucherTable";
+import { workerTable } from "@/db/tables/workerTable";
+import { employmentTable } from "@/db/tables/employmentTable";
+import { db } from "@/lib/db";
+import type {
+    PayrollStatus,
+    WorkerEmploymentArrangement,
+    WorkerEmploymentType,
+} from "@/types/status";
+
+export type PayrollSelectionRow = SelectPayroll & {
+    workerName: string;
+    status: PayrollStatus;
+    employmentType: WorkerEmploymentType;
+    employmentArrangement: WorkerEmploymentArrangement;
+    voucherNumber: string | null;
+};
+
+export async function queryPayrollSelectionRows(
+    statusFilter?: PayrollStatus,
+): Promise<PayrollSelectionRow[]> {
+    const baseQuery = db
+        .select({
+            payroll: payrollTable,
+            workerName: workerTable.name,
+            employmentType: employmentTable.employmentType,
+            employmentArrangement: employmentTable.employmentArrangement,
+            voucherNumber: payrollVoucherTable.voucherNumber,
+        })
+        .from(payrollTable)
+        .innerJoin(workerTable, eq(payrollTable.workerId, workerTable.id))
+        .innerJoin(
+            employmentTable,
+            eq(workerTable.employmentId, employmentTable.id),
+        )
+        .innerJoin(
+            payrollVoucherTable,
+            eq(payrollTable.payrollVoucherId, payrollVoucherTable.id),
+        );
+
+    const filtered =
+        statusFilter !== undefined
+            ? baseQuery.where(eq(payrollTable.status, statusFilter))
+            : baseQuery;
+
+    const rows = await filtered.orderBy(
+        asc(workerTable.name),
+        asc(payrollTable.periodStart),
+    );
+
+    return rows.map((row) => ({
+        ...row.payroll,
+        workerName: row.workerName,
+        employmentType: row.employmentType,
+        employmentArrangement: row.employmentArrangement,
+        voucherNumber: row.voucherNumber,
+    }));
+}

--- a/services/payroll/_shared/refresh-draft-payroll-voucher.ts
+++ b/services/payroll/_shared/refresh-draft-payroll-voucher.ts
@@ -1,0 +1,100 @@
+import { and, eq, gte, lte } from "drizzle-orm";
+
+import { advanceRequestTable } from "@/db/tables/advanceRequestTable";
+import { advanceTable } from "@/db/tables/advanceTable";
+import { employmentTable } from "@/db/tables/employmentTable";
+import { payrollTable } from "@/db/tables/payrollTable";
+import { payrollVoucherTable } from "@/db/tables/payrollVoucherTable";
+import { timesheetTable } from "@/db/tables/timesheetTable";
+import { db } from "@/lib/db";
+import { buildDraftPayrollVoucherValues } from "@/services/payroll/draft-payroll-voucher-values";
+import { countPayrollPublicHolidays } from "@/services/payroll/public-holiday-payroll";
+
+export type DraftPayrollExecutor = Pick<typeof db, "select" | "update">;
+
+export type DraftPayrollRefreshRow = Pick<
+    typeof payrollTable.$inferSelect,
+    "id" | "workerId" | "payrollVoucherId" | "periodStart" | "periodEnd"
+>;
+
+export async function refreshDraftPayrollVoucher(
+    executor: DraftPayrollExecutor,
+    args: {
+        payroll: DraftPayrollRefreshRow;
+        employment: typeof employmentTable.$inferSelect;
+        restDays: number;
+        /** When provided, skips an extra timesheet round-trip (callers often already fetched these rows to derive `restDays`). */
+        timesheetEntries?: Array<{
+            hours: typeof timesheetTable.$inferSelect.hours;
+            dateIn: typeof timesheetTable.$inferSelect.dateIn;
+        }>;
+    },
+): Promise<void> {
+    const { payroll, employment, restDays, timesheetEntries } = args;
+
+    const entryRows =
+        timesheetEntries ??
+        (await executor
+            .select({
+                hours: timesheetTable.hours,
+                dateIn: timesheetTable.dateIn,
+            })
+            .from(timesheetTable)
+            .where(
+                and(
+                    eq(timesheetTable.workerId, payroll.workerId),
+                    gte(timesheetTable.dateIn, payroll.periodStart),
+                    lte(timesheetTable.dateOut, payroll.periodEnd),
+                ),
+            ));
+
+    const totalHoursWorked = entryRows.reduce(
+        (sum, entry) => sum + Number(entry.hours),
+        0,
+    );
+    const publicHolidays = await countPayrollPublicHolidays(
+        {
+            periodStart: payroll.periodStart,
+            periodEnd: payroll.periodEnd,
+            workedDateIns: entryRows.map((entry) => entry.dateIn),
+        },
+        executor,
+    );
+
+    const advanceRows = await executor
+        .select({
+            amount: advanceTable.amount,
+            status: advanceTable.status,
+        })
+        .from(advanceTable)
+        .innerJoin(
+            advanceRequestTable,
+            eq(advanceTable.advanceRequestId, advanceRequestTable.id),
+        )
+        .where(
+            and(
+                eq(advanceRequestTable.workerId, payroll.workerId),
+                gte(advanceTable.repaymentDate, payroll.periodStart),
+                lte(advanceTable.repaymentDate, payroll.periodEnd),
+            ),
+        );
+    const advanceTotal = advanceRows
+        .filter((advance) => advance.status === "Installment Loan")
+        .reduce((sum, advance) => sum + advance.amount, 0);
+
+    const voucherValues = buildDraftPayrollVoucherValues({
+        employment,
+        totalHoursWorked,
+        restDays,
+        publicHolidays,
+        advanceTotal,
+    });
+
+    await executor
+        .update(payrollVoucherTable)
+        .set({
+            ...voucherValues,
+            updatedAt: new Date(),
+        })
+        .where(eq(payrollVoucherTable.id, payroll.payrollVoucherId));
+}

--- a/services/payroll/_shared/voucher-update-pipeline.ts
+++ b/services/payroll/_shared/voucher-update-pipeline.ts
@@ -4,6 +4,46 @@ import { db } from "@/lib/db";
 import { payrollTable } from "@/db/tables/payrollTable";
 import { payrollVoucherTable } from "@/db/tables/payrollVoucherTable";
 import { buildDraftPayrollVoucherValues } from "@/services/payroll/draft-payroll-voucher-values";
+import type { WorkerEmploymentType } from "@/types/status";
+
+export type VoucherMutationResult =
+    | {
+          success: true;
+          payrollId: string;
+          voucherId: string;
+      }
+    | {
+          success: false;
+          code:
+              | "VALIDATION_ERROR"
+              | "NOT_FOUND"
+              | "CONFLICT"
+              | "INTERNAL_ERROR";
+          error: string;
+      };
+
+export function validatePayrollAndVoucherIds(
+    payrollId: string | undefined | null,
+    voucherId: string | undefined | null,
+):
+    | { ok: true; payrollId: string; voucherId: string }
+    | { ok: false; result: Extract<VoucherMutationResult, { success: false }> } {
+    if (!voucherId || !payrollId) {
+        return {
+            ok: false,
+            result: {
+                success: false,
+                code: "VALIDATION_ERROR",
+                error: "Missing voucherId or payrollId",
+            },
+        };
+    }
+    return { ok: true, payrollId, voucherId };
+}
+
+export function normalizeEmploymentTypeForVoucher(raw: string | null): WorkerEmploymentType {
+    return raw === "Part Time" ? "Part Time" : "Full Time";
+}
 
 export type VoucherMutationGuardFailure = {
     success: false;

--- a/services/payroll/get-revert-preview.ts
+++ b/services/payroll/get-revert-preview.ts
@@ -5,6 +5,7 @@ import { payrollTable } from "@/db/tables/payrollTable";
 import { timesheetTable } from "@/db/tables/timesheetTable";
 import { advanceTable } from "@/db/tables/advanceTable";
 import { advanceRequestTable } from "@/db/tables/advanceRequestTable";
+import { advanceRepaymentInPayrollWindowWhere } from "@/services/payroll/_shared/advance-repayment-window";
 
 export type RevertPreviewTimesheetLine = {
     id: string;
@@ -110,13 +111,7 @@ export async function getPayrollRevertPreview(
             advanceRequestTable,
             eq(advanceTable.advanceRequestId, advanceRequestTable.id),
         )
-        .where(
-            and(
-                eq(advanceRequestTable.workerId, payroll.workerId),
-                gte(advanceTable.repaymentDate, payroll.periodStart),
-                lte(advanceTable.repaymentDate, payroll.periodEnd),
-            ),
-        );
+        .where(advanceRepaymentInPayrollWindowWhere(payroll));
 
     const installmentPaidInPeriod = advancesInPeriod
         .filter((advance) => advance.status === "Installment Paid")

--- a/services/payroll/list-draft-payrolls-for-settlement.ts
+++ b/services/payroll/list-draft-payrolls-for-settlement.ts
@@ -1,53 +1,12 @@
-import { asc, eq } from "drizzle-orm";
+import {
+    queryPayrollSelectionRows,
+    type PayrollSelectionRow,
+} from "@/services/payroll/_shared/query-payroll-selection-rows";
 
-import { payrollTable, type SelectPayroll } from "@/db/tables/payrollTable";
-import { payrollVoucherTable } from "@/db/tables/payrollVoucherTable";
-import { workerTable } from "@/db/tables/workerTable";
-import { employmentTable } from "@/db/tables/employmentTable";
-import { db } from "@/lib/db";
-import type {
-    PayrollStatus,
-    WorkerEmploymentArrangement,
-    WorkerEmploymentType,
-} from "@/types/status";
-
-export type PayrollSelectionRow = SelectPayroll & {
-    workerName: string;
-    status: PayrollStatus;
-    employmentType: WorkerEmploymentType;
-    employmentArrangement: WorkerEmploymentArrangement;
-    voucherNumber: string | null;
-};
+export type { PayrollSelectionRow };
 
 export async function listDraftPayrollsForSettlement(): Promise<
     PayrollSelectionRow[]
 > {
-    const rows = await db
-        .select({
-            payroll: payrollTable,
-            workerName: workerTable.name,
-            employmentType: employmentTable.employmentType,
-            employmentArrangement: employmentTable.employmentArrangement,
-            voucherNumber: payrollVoucherTable.voucherNumber,
-        })
-        .from(payrollTable)
-        .innerJoin(workerTable, eq(payrollTable.workerId, workerTable.id))
-        .innerJoin(
-            employmentTable,
-            eq(workerTable.employmentId, employmentTable.id),
-        )
-        .innerJoin(
-            payrollVoucherTable,
-            eq(payrollTable.payrollVoucherId, payrollVoucherTable.id),
-        )
-        .where(eq(payrollTable.status, "Draft"))
-        .orderBy(asc(workerTable.name), asc(payrollTable.periodStart));
-
-    return rows.map((row) => ({
-        ...row.payroll,
-        workerName: row.workerName,
-        employmentType: row.employmentType,
-        employmentArrangement: row.employmentArrangement,
-        voucherNumber: row.voucherNumber,
-    }));
+    return queryPayrollSelectionRows("Draft");
 }

--- a/services/payroll/list-payrolls-for-download.ts
+++ b/services/payroll/list-payrolls-for-download.ts
@@ -1,38 +1,6 @@
-import { asc, eq } from "drizzle-orm";
-
-import { payrollTable } from "@/db/tables/payrollTable";
-import { payrollVoucherTable } from "@/db/tables/payrollVoucherTable";
-import { workerTable } from "@/db/tables/workerTable";
-import { employmentTable } from "@/db/tables/employmentTable";
-import { db } from "@/lib/db";
-import type { PayrollSelectionRow } from "@/services/payroll/list-draft-payrolls-for-settlement";
+import type { PayrollSelectionRow } from "@/services/payroll/_shared/query-payroll-selection-rows";
+import { queryPayrollSelectionRows } from "@/services/payroll/_shared/query-payroll-selection-rows";
 
 export async function listPayrollsForDownload(): Promise<PayrollSelectionRow[]> {
-    const rows = await db
-        .select({
-            payroll: payrollTable,
-            workerName: workerTable.name,
-            employmentType: employmentTable.employmentType,
-            employmentArrangement: employmentTable.employmentArrangement,
-            voucherNumber: payrollVoucherTable.voucherNumber,
-        })
-        .from(payrollTable)
-        .innerJoin(workerTable, eq(payrollTable.workerId, workerTable.id))
-        .innerJoin(
-            employmentTable,
-            eq(workerTable.employmentId, employmentTable.id),
-        )
-        .innerJoin(
-            payrollVoucherTable,
-            eq(payrollTable.payrollVoucherId, payrollVoucherTable.id),
-        )
-        .orderBy(asc(workerTable.name), asc(payrollTable.periodStart));
-
-    return rows.map((row) => ({
-        ...row.payroll,
-        workerName: row.workerName,
-        employmentType: row.employmentType,
-        employmentArrangement: row.employmentArrangement,
-        voucherNumber: row.voucherNumber,
-    }));
+    return queryPayrollSelectionRows();
 }

--- a/services/payroll/monthly-dashboard-aggregation.ts
+++ b/services/payroll/monthly-dashboard-aggregation.ts
@@ -1,20 +1,6 @@
-import { and, eq, gte, lte, sql } from "drizzle-orm";
+import { and, eq, gte, lte } from "drizzle-orm";
 
 import { payrollTable } from "@/db/tables/payrollTable";
-
-/** Last five calendar years ending at `now`, used by dashboard payroll aggregate queries. */
-export function payrollDashboardYearWindow(now = new Date()) {
-    const maxYear = now.getFullYear();
-    const minYear = maxYear - 4;
-    const yearOptions = Array.from({ length: 5 }, (_, i) => maxYear - i);
-    return { maxYear, minYear, yearOptions };
-}
-
-export function payrollPeriodEndYearMonthExtract() {
-    const yearExpr = sql<number>`extract(year from ${payrollTable.periodEnd})::int`;
-    const monthExpr = sql<number>`extract(month from ${payrollTable.periodEnd})::int`;
-    return { yearExpr, monthExpr };
-}
 
 export function settledPayrollOverlappingYearsWhere(minYear: number, maxYear: number) {
     return and(

--- a/services/payroll/payroll-command-shared.ts
+++ b/services/payroll/payroll-command-shared.ts
@@ -5,6 +5,7 @@ import { advanceRequestTable } from "@/db/tables/advanceRequestTable";
 import { advanceTable } from "@/db/tables/advanceTable";
 import { payrollTable } from "@/db/tables/payrollTable";
 import { timesheetTable } from "@/db/tables/timesheetTable";
+import { advanceRepaymentInPayrollWindowWhere } from "@/services/payroll/_shared/advance-repayment-window";
 
 export type PayrollCommandTransaction = Parameters<
     Parameters<typeof db.transaction>[0]
@@ -21,7 +22,7 @@ type RequestAdvanceRow = {
     status: "Installment Loan" | "Installment Paid";
 };
 
-type PayrollTarget = {
+export type PayrollTarget = {
     id: string;
     workerId: string;
     periodStart: string;
@@ -88,6 +89,42 @@ async function updateAdvanceRequestStatuses(
     }
 }
 
+async function syncAdvanceRequestStatusesFromAdvances(
+    tx: PayrollCommandTransaction,
+    advances: Array<{ advanceRequestId: string }>,
+    now: Date,
+) {
+    const requestIds = Array.from(
+        new Set(advances.map((advance) => advance.advanceRequestId)),
+    );
+    await updateAdvanceRequestStatuses(tx, requestIds, now);
+}
+
+async function updateTimesheetsInPayrollPeriod(
+    tx: PayrollCommandTransaction,
+    payroll: PayrollTarget,
+    args: {
+        fromStatus: "Timesheet Paid" | "Timesheet Unpaid";
+        toStatus: "Timesheet Paid" | "Timesheet Unpaid";
+        now: Date;
+    },
+) {
+    await tx
+        .update(timesheetTable)
+        .set({
+            status: args.toStatus,
+            updatedAt: args.now,
+        })
+        .where(
+            and(
+                eq(timesheetTable.workerId, payroll.workerId),
+                gte(timesheetTable.dateIn, payroll.periodStart),
+                lte(timesheetTable.dateOut, payroll.periodEnd),
+                eq(timesheetTable.status, args.fromStatus),
+            ),
+        );
+}
+
 export async function settlePayrollInTx(
     tx: PayrollCommandTransaction,
     payroll: PayrollTarget,
@@ -112,13 +149,7 @@ export async function settlePayrollInTx(
             advanceRequestTable,
             eq(advanceTable.advanceRequestId, advanceRequestTable.id),
         )
-        .where(
-            and(
-                eq(advanceRequestTable.workerId, payroll.workerId),
-                gte(advanceTable.repaymentDate, payroll.periodStart),
-                lte(advanceTable.repaymentDate, payroll.periodEnd),
-            ),
-        );
+        .where(advanceRepaymentInPayrollWindowWhere(payroll));
 
     const installmentLoanIds = advancesInPeriod
         .filter((advance) => advance.status === "Installment Loan")
@@ -134,26 +165,13 @@ export async function settlePayrollInTx(
             .where(inArray(advanceTable.id, installmentLoanIds));
     }
 
-    const requestIds = Array.from(
-        new Set(advancesInPeriod.map((advance) => advance.advanceRequestId)),
-    );
+    await syncAdvanceRequestStatusesFromAdvances(tx, advancesInPeriod, now);
 
-    await updateAdvanceRequestStatuses(tx, requestIds, now);
-
-    await tx
-        .update(timesheetTable)
-        .set({
-            status: "Timesheet Paid",
-            updatedAt: now,
-        })
-        .where(
-            and(
-                eq(timesheetTable.workerId, payroll.workerId),
-                gte(timesheetTable.dateIn, payroll.periodStart),
-                lte(timesheetTable.dateOut, payroll.periodEnd),
-                eq(timesheetTable.status, "Timesheet Unpaid"),
-            ),
-        );
+    await updateTimesheetsInPayrollPeriod(tx, payroll, {
+        fromStatus: "Timesheet Unpaid",
+        toStatus: "Timesheet Paid",
+        now,
+    });
 }
 
 export async function revertPayrollInTx(
@@ -180,13 +198,7 @@ export async function revertPayrollInTx(
             advanceRequestTable,
             eq(advanceTable.advanceRequestId, advanceRequestTable.id),
         )
-        .where(
-            and(
-                eq(advanceRequestTable.workerId, payroll.workerId),
-                gte(advanceTable.repaymentDate, payroll.periodStart),
-                lte(advanceTable.repaymentDate, payroll.periodEnd),
-            ),
-        );
+        .where(advanceRepaymentInPayrollWindowWhere(payroll));
 
     const installmentPaidIds = advancesInPeriod
         .filter((advance) => advance.status === "Installment Paid")
@@ -202,24 +214,11 @@ export async function revertPayrollInTx(
             .where(inArray(advanceTable.id, installmentPaidIds));
     }
 
-    const requestIds = Array.from(
-        new Set(advancesInPeriod.map((advance) => advance.advanceRequestId)),
-    );
+    await syncAdvanceRequestStatusesFromAdvances(tx, advancesInPeriod, now);
 
-    await updateAdvanceRequestStatuses(tx, requestIds, now);
-
-    await tx
-        .update(timesheetTable)
-        .set({
-            status: "Timesheet Unpaid",
-            updatedAt: now,
-        })
-        .where(
-            and(
-                eq(timesheetTable.workerId, payroll.workerId),
-                gte(timesheetTable.dateIn, payroll.periodStart),
-                lte(timesheetTable.dateOut, payroll.periodEnd),
-                eq(timesheetTable.status, "Timesheet Paid"),
-            ),
-        );
+    await updateTimesheetsInPayrollPeriod(tx, payroll, {
+        fromStatus: "Timesheet Paid",
+        toStatus: "Timesheet Unpaid",
+        now,
+    });
 }

--- a/services/payroll/refresh-affected-draft-payrolls-for-public-holiday-year.ts
+++ b/services/payroll/refresh-affected-draft-payrolls-for-public-holiday-year.ts
@@ -1,11 +1,8 @@
 import { and, eq, gte, lte } from "drizzle-orm";
 
 import { db } from "@/lib/db";
-import { advanceRequestTable } from "@/db/tables/advanceRequestTable";
-import { advanceTable } from "@/db/tables/advanceTable";
 import { employmentTable } from "@/db/tables/employmentTable";
 import { payrollTable } from "@/db/tables/payrollTable";
-import { payrollVoucherTable } from "@/db/tables/payrollVoucherTable";
 import { timesheetTable } from "@/db/tables/timesheetTable";
 import { workerTable } from "@/db/tables/workerTable";
 import {
@@ -13,16 +10,12 @@ import {
     countSundaysInPeriod,
     restDaysFromMissingDateCount,
 } from "@/utils/payroll/missing-timesheet-dates";
-import { countPayrollPublicHolidays } from "@/services/payroll/public-holiday-payroll";
-import { buildDraftPayrollVoucherValues } from "@/services/payroll/draft-payroll-voucher-values";
+import {
+    refreshDraftPayrollVoucher,
+    type DraftPayrollExecutor,
+} from "@/services/payroll/_shared/refresh-draft-payroll-voucher";
 
 type DbTransaction = Parameters<Parameters<typeof db.transaction>[0]>[0];
-type DraftPayrollRefreshExecutor = Pick<typeof db, "select" | "update">;
-
-type DraftPayrollRow = Pick<
-    typeof payrollTable.$inferSelect,
-    "id" | "workerId" | "payrollVoucherId" | "periodStart" | "periodEnd"
->;
 
 type DraftPayrollRefreshResult =
     | { success: true; affectedPayrollIds: string[] }
@@ -36,7 +29,7 @@ function yearRange(year: number) {
 }
 
 async function refreshAffectedDraftPayrollsForPublicHolidayYearWithExecutor(
-    executor: DraftPayrollRefreshExecutor,
+    executor: DraftPayrollExecutor,
     input: {
         year: number;
     },
@@ -90,12 +83,45 @@ async function refreshAffectedDraftPayrollsForPublicHolidayYearWithExecutor(
                 employmentByWorkerId.set(payroll.workerId, employment);
             }
 
-            await refreshDraftPayrollVoucher(executor, payroll, employment);
+            const entryRows = await executor
+                .select({
+                    hours: timesheetTable.hours,
+                    dateIn: timesheetTable.dateIn,
+                })
+                .from(timesheetTable)
+                .where(
+                    and(
+                        eq(timesheetTable.workerId, payroll.workerId),
+                        gte(timesheetTable.dateIn, payroll.periodStart),
+                        lte(timesheetTable.dateOut, payroll.periodEnd),
+                    ),
+                );
+
+            const missingCount = countMissingTimesheetDateIns({
+                periodStart: payroll.periodStart,
+                periodEnd: payroll.periodEnd,
+                presentDateInKeys: entryRows.map((entry) => entry.dateIn),
+            });
+            const sundayBudget = countSundaysInPeriod({
+                periodStart: payroll.periodStart,
+                periodEnd: payroll.periodEnd,
+            });
+            const restDays = restDaysFromMissingDateCount(
+                missingCount,
+                sundayBudget,
+            );
+
+            await refreshDraftPayrollVoucher(executor, {
+                payroll,
+                employment,
+                restDays,
+                timesheetEntries: entryRows,
+            });
         }
 
         return {
             success: true,
-            affectedPayrollIds: drafts.map((payroll) => payroll.id),
+            affectedPayrollIds: drafts.map((p) => p.id),
         };
     } catch (error) {
         console.error(
@@ -104,83 +130,6 @@ async function refreshAffectedDraftPayrollsForPublicHolidayYearWithExecutor(
         );
         return { error: "Failed to refresh affected Draft payrolls" };
     }
-}
-
-async function refreshDraftPayrollVoucher(
-    executor: DraftPayrollRefreshExecutor,
-    payroll: DraftPayrollRow,
-    employment: typeof employmentTable.$inferSelect,
-) {
-    const entryRows = await executor
-        .select({
-            hours: timesheetTable.hours,
-            dateIn: timesheetTable.dateIn,
-        })
-        .from(timesheetTable)
-        .where(
-            and(
-                eq(timesheetTable.workerId, payroll.workerId),
-                gte(timesheetTable.dateIn, payroll.periodStart),
-                lte(timesheetTable.dateOut, payroll.periodEnd),
-            ),
-        );
-
-    const totalHoursWorked = entryRows.reduce(
-        (sum, entry) => sum + Number(entry.hours),
-        0,
-    );
-    const missingCount = countMissingTimesheetDateIns({
-        periodStart: payroll.periodStart,
-        periodEnd: payroll.periodEnd,
-        presentDateInKeys: entryRows.map((entry) => entry.dateIn),
-    });
-    const sundayBudget = countSundaysInPeriod({
-        periodStart: payroll.periodStart,
-        periodEnd: payroll.periodEnd,
-    });
-    const restDays = restDaysFromMissingDateCount(missingCount, sundayBudget);
-    const publicHolidays = await countPayrollPublicHolidays(
-        {
-            periodStart: payroll.periodStart,
-            periodEnd: payroll.periodEnd,
-            workedDateIns: entryRows.map((entry) => entry.dateIn),
-        },
-        executor,
-    );
-    const advanceRows = await executor
-        .select({
-            amount: advanceTable.amount,
-            status: advanceTable.status,
-        })
-        .from(advanceTable)
-        .innerJoin(
-            advanceRequestTable,
-            eq(advanceTable.advanceRequestId, advanceRequestTable.id),
-        )
-        .where(
-            and(
-                eq(advanceRequestTable.workerId, payroll.workerId),
-                gte(advanceTable.repaymentDate, payroll.periodStart),
-                lte(advanceTable.repaymentDate, payroll.periodEnd),
-            ),
-        );
-    const advanceTotal = advanceRows
-        .filter((advance) => advance.status === "Installment Loan")
-        .reduce((sum, advance) => sum + advance.amount, 0);
-    const voucherValues = buildDraftPayrollVoucherValues({
-        employment,
-        totalHoursWorked,
-        restDays,
-        publicHolidays,
-        advanceTotal,
-    });
-    await executor
-        .update(payrollVoucherTable)
-        .set({
-            ...voucherValues,
-            updatedAt: new Date(),
-        })
-        .where(eq(payrollVoucherTable.id, payroll.payrollVoucherId));
 }
 
 export async function refreshAffectedDraftPayrollsForPublicHolidayYear(input: {
@@ -199,7 +148,7 @@ export async function refreshAffectedDraftPayrollsForPublicHolidayYearInTx(
     },
 ): Promise<DraftPayrollRefreshResult> {
     return refreshAffectedDraftPayrollsForPublicHolidayYearWithExecutor(
-        tx as unknown as DraftPayrollRefreshExecutor,
+        tx as unknown as DraftPayrollExecutor,
         input,
     );
 }

--- a/services/payroll/save-payroll.ts
+++ b/services/payroll/save-payroll.ts
@@ -91,35 +91,34 @@ function isPayrollOverlapConstraintError(error: unknown): boolean {
     return dbError.constraint === PAYROLL_PERIOD_OVERLAP_CONSTRAINT;
 }
 
-async function recordPayrollCreationWorkflowCompletion() {
-    try {
-        await recordGuidedMonthlyWorkflowStepCompletion({
-            stepId: "payroll_creation",
-        });
-    } catch (error) {
-        console.error(
-            "Failed to record guided monthly workflow completion for payroll creation",
-            error,
-        );
-    }
+type DraftVoucherInputsExecutor = Pick<typeof db, "select">;
+
+async function fetchWorkerWithEmployment(workerId: string) {
+    const [row] = await db
+        .select({
+            worker: workerTable,
+            employment: employmentTable,
+        })
+        .from(workerTable)
+        .innerJoin(
+            employmentTable,
+            eq(workerTable.employmentId, employmentTable.id),
+        )
+        .where(eq(workerTable.id, workerId))
+        .limit(1);
+    return row ?? null;
 }
 
-async function createPayrollForWorkerInExecutor(
-    executor: CreatePayrollExecutor,
+async function computeDraftVoucherInputs(
+    executor: DraftVoucherInputsExecutor,
     input: {
         workerId: string;
-        employment: typeof employmentTable.$inferSelect;
         periodStart: string;
         periodEnd: string;
-        payrollDate: string;
+        employment: typeof employmentTable.$inferSelect;
     },
 ) {
-    const { workerId, employment, periodStart, periodEnd, payrollDate } = input;
-    const voucherYear = Number.parseInt(payrollDate.slice(0, 4), 10);
-
-    if (Number.isNaN(voucherYear)) {
-        throw new Error(`Invalid payroll date for voucher numbering: ${payrollDate}`);
-    }
+    const { workerId, periodStart, periodEnd, employment } = input;
 
     const entries = await executor
         .select()
@@ -157,12 +156,51 @@ async function createPayrollForWorkerInExecutor(
     const advanceTotal = advances
         .filter((advance) => advance.status === "Installment Loan")
         .reduce((sum, advance) => sum + advance.amount, 0);
-    const voucherValues = buildDraftPayrollVoucherValues({
+
+    return buildDraftPayrollVoucherValues({
         employment,
         totalHoursWorked,
         restDays,
         publicHolidays,
         advanceTotal,
+    });
+}
+
+async function recordPayrollCreationWorkflowCompletion() {
+    try {
+        await recordGuidedMonthlyWorkflowStepCompletion({
+            stepId: "payroll_creation",
+        });
+    } catch (error) {
+        console.error(
+            "Failed to record guided monthly workflow completion for payroll creation",
+            error,
+        );
+    }
+}
+
+async function createPayrollForWorkerInExecutor(
+    executor: CreatePayrollExecutor,
+    input: {
+        workerId: string;
+        employment: typeof employmentTable.$inferSelect;
+        periodStart: string;
+        periodEnd: string;
+        payrollDate: string;
+    },
+) {
+    const { workerId, employment, periodStart, periodEnd, payrollDate } = input;
+    const voucherYear = Number.parseInt(payrollDate.slice(0, 4), 10);
+
+    if (Number.isNaN(voucherYear)) {
+        throw new Error(`Invalid payroll date for voucher numbering: ${payrollDate}`);
+    }
+
+    const voucherValues = await computeDraftVoucherInputs(executor, {
+        workerId,
+        periodStart,
+        periodEnd,
+        employment,
     });
     const [voucher] = await executor
         .insert(payrollVoucherTable)
@@ -210,18 +248,7 @@ export async function createPayrollRecord(input: {
         return { error: rangeValidation.error };
     }
 
-    const [row] = await db
-        .select({
-            worker: workerTable,
-            employment: employmentTable,
-        })
-        .from(workerTable)
-        .innerJoin(
-            employmentTable,
-            eq(workerTable.employmentId, employmentTable.id),
-        )
-        .where(eq(workerTable.id, workerId))
-        .limit(1);
+    const row = await fetchWorkerWithEmployment(workerId);
 
     if (!row) {
         return { error: "Worker not found" };
@@ -306,18 +333,7 @@ export async function createPayrollRecords(input: {
     const conflicts: PayrollPeriodConflict[] = [];
 
     for (const workerId of uniqueWorkerIds) {
-        const [row] = await db
-            .select({
-                worker: workerTable,
-                employment: employmentTable,
-            })
-            .from(workerTable)
-            .innerJoin(
-                employmentTable,
-                eq(workerTable.employmentId, employmentTable.id),
-            )
-            .where(eq(workerTable.id, workerId))
-            .limit(1);
+        const row = await fetchWorkerWithEmployment(workerId);
 
         if (!row) continue;
 
@@ -412,18 +428,7 @@ export async function updatePayrollRecord(input: {
         return { error: "Only Draft payrolls can be edited" };
     }
 
-    const [row] = await db
-        .select({
-            worker: workerTable,
-            employment: employmentTable,
-        })
-        .from(workerTable)
-        .innerJoin(
-            employmentTable,
-            eq(workerTable.employmentId, employmentTable.id),
-        )
-        .where(eq(workerTable.id, existing.workerId))
-        .limit(1);
+    const row = await fetchWorkerWithEmployment(existing.workerId);
 
     if (!row) return { error: "Worker not found" };
 
@@ -437,42 +442,11 @@ export async function updatePayrollRecord(input: {
         return buildPayrollOverlapErrorResult(preConflicts);
     }
 
-    const entries = await db
-        .select()
-        .from(timesheetTable)
-        .where(
-            and(
-                eq(timesheetTable.workerId, existing.workerId),
-                gte(timesheetTable.dateIn, periodStart),
-                lte(timesheetTable.dateOut, periodEnd),
-            ),
-        );
-
-    const totalHoursWorked = entries.reduce((sum, e) => sum + Number(e.hours), 0);
-    const restDays = computeRestDaysForPayrollPeriod({
+    const voucherValues = await computeDraftVoucherInputs(db, {
+        workerId: existing.workerId,
         periodStart,
         periodEnd,
-        presentDateInKeys: entries.map((e) => e.dateIn),
-    });
-    const publicHolidays = await countPayrollPublicHolidays({
-        periodStart,
-        periodEnd,
-        workedDateIns: entries.map((entry) => entry.dateIn),
-    });
-    const advances = await getAdvancesForPayrollPeriod(
-        existing.workerId,
-        periodStart,
-        periodEnd,
-    );
-    const advanceTotal = advances
-        .filter((a) => a.status === "Installment Loan")
-        .reduce((sum, a) => sum + a.amount, 0);
-    const voucherValues = buildDraftPayrollVoucherValues({
         employment: row.employment,
-        totalHoursWorked,
-        restDays,
-        publicHolidays,
-        advanceTotal,
     });
 
     try {

--- a/services/payroll/synchronize-worker-draft-payrolls.ts
+++ b/services/payroll/synchronize-worker-draft-payrolls.ts
@@ -1,24 +1,22 @@
 import { and, eq, gte, lte } from "drizzle-orm";
 
 import { db } from "@/lib/db";
-import { advanceRequestTable } from "@/db/tables/advanceRequestTable";
-import { advanceTable } from "@/db/tables/advanceTable";
 import { employmentTable } from "@/db/tables/employmentTable";
 import { payrollTable } from "@/db/tables/payrollTable";
-import { payrollVoucherTable } from "@/db/tables/payrollVoucherTable";
 import { timesheetTable } from "@/db/tables/timesheetTable";
 import { workerTable } from "@/db/tables/workerTable";
 import { computeRestDaysForPayrollPeriod } from "@/utils/payroll/missing-timesheet-dates";
-import { countPayrollPublicHolidays } from "@/services/payroll/public-holiday-payroll";
-import { buildDraftPayrollVoucherValues } from "@/services/payroll/draft-payroll-voucher-values";
+import {
+    refreshDraftPayrollVoucher,
+    type DraftPayrollExecutor,
+} from "@/services/payroll/_shared/refresh-draft-payroll-voucher";
 
 type DbTransaction = Parameters<Parameters<typeof db.transaction>[0]>[0];
-type PayrollSyncExecutor = Pick<typeof db, "select" | "update">;
 
 export type PayrollSyncResult = { success: true } | { error: string };
 
 async function synchronizeWorkerDraftPayrollsWithExecutor(
-    executor: PayrollSyncExecutor,
+    executor: DraftPayrollExecutor,
     input: {
         workerId: string;
     },
@@ -72,59 +70,19 @@ async function synchronizeWorkerDraftPayrollsWithExecutor(
                         lte(timesheetTable.dateOut, payroll.periodEnd),
                     ),
                 );
-            const totalHoursWorked = entryRows.reduce(
-                (sum, entry) => sum + Number(entry.hours),
-                0,
-            );
 
             const restDays = computeRestDaysForPayrollPeriod({
                 periodStart: payroll.periodStart,
                 periodEnd: payroll.periodEnd,
                 presentDateInKeys: entryRows.map((e) => e.dateIn),
             });
-            const publicHolidays = await countPayrollPublicHolidays(
-                {
-                    periodStart: payroll.periodStart,
-                    periodEnd: payroll.periodEnd,
-                    workedDateIns: entryRows.map((entry) => entry.dateIn),
-                },
-                executor,
-            );
 
-            const advanceRows = await executor
-                .select({
-                    amount: advanceTable.amount,
-                    status: advanceTable.status,
-                })
-                .from(advanceTable)
-                .innerJoin(
-                    advanceRequestTable,
-                    eq(advanceTable.advanceRequestId, advanceRequestTable.id),
-                )
-                .where(
-                    and(
-                        eq(advanceRequestTable.workerId, workerId),
-                        gte(advanceTable.repaymentDate, payroll.periodStart),
-                        lte(advanceTable.repaymentDate, payroll.periodEnd),
-                    ),
-                );
-            const advanceTotal = advanceRows
-                .filter((advance) => advance.status === "Installment Loan")
-                .reduce((sum, advance) => sum + advance.amount, 0);
-            const voucherValues = buildDraftPayrollVoucherValues({
+            await refreshDraftPayrollVoucher(executor, {
+                payroll,
                 employment,
-                totalHoursWorked,
                 restDays,
-                publicHolidays,
-                advanceTotal,
+                timesheetEntries: entryRows,
             });
-            await executor
-                .update(payrollVoucherTable)
-                .set({
-                    ...voucherValues,
-                    updatedAt: new Date(),
-                })
-                .where(eq(payrollVoucherTable.id, payroll.payrollVoucherId));
         }
 
         return { success: true };
@@ -147,7 +105,7 @@ export async function synchronizeWorkerDraftPayrollsInTx(
     },
 ): Promise<PayrollSyncResult> {
     return synchronizeWorkerDraftPayrollsWithExecutor(
-        tx as unknown as PayrollSyncExecutor,
+        tx as unknown as DraftPayrollExecutor,
         input,
     );
 }

--- a/services/payroll/update-voucher-days.ts
+++ b/services/payroll/update-voucher-days.ts
@@ -4,25 +4,14 @@ import { db } from "@/lib/db";
 import { payrollVoucherTable } from "@/db/tables/payrollVoucherTable";
 import {
     assertDraftPayrollVoucher,
+    normalizeEmploymentTypeForVoucher,
     persistDraftPayrollVoucherUpdate,
+    validatePayrollAndVoucherIds,
+    type VoucherMutationResult,
 } from "@/services/payroll/_shared/voucher-update-pipeline";
 import { buildDraftPayrollVoucherValues } from "@/services/payroll/draft-payroll-voucher-values";
 
-export type UpdateVoucherDaysResult =
-    | {
-          success: true;
-          payrollId: string;
-          voucherId: string;
-      }
-    | {
-          success: false;
-          code:
-              | "VALIDATION_ERROR"
-              | "NOT_FOUND"
-              | "CONFLICT"
-              | "INTERNAL_ERROR";
-          error: string;
-      };
+export type UpdateVoucherDaysResult = VoucherMutationResult;
 
 export async function updateVoucherDays(input: {
     payrollId: string;
@@ -30,15 +19,15 @@ export async function updateVoucherDays(input: {
     restDays: number;
     publicHolidays: number;
 }): Promise<UpdateVoucherDaysResult> {
-    const { payrollId, voucherId, restDays, publicHolidays } = input;
-
-    if (!voucherId || !payrollId) {
-        return {
-            success: false,
-            code: "VALIDATION_ERROR",
-            error: "Missing voucherId or payrollId",
-        };
+    const identifiers = validatePayrollAndVoucherIds(
+        input.payrollId,
+        input.voucherId,
+    );
+    if (!identifiers.ok) {
+        return identifiers.result;
     }
+    const { payrollId, voucherId } = identifiers;
+    const { restDays, publicHolidays } = input;
     if (!Number.isFinite(restDays) || restDays < 0) {
         return {
             success: false,
@@ -94,10 +83,9 @@ export async function updateVoucherDays(input: {
 
     const voucherValues = buildDraftPayrollVoucherValues({
         employment: {
-            employmentType:
-                voucher.employmentType === "Part Time"
-                    ? "Part Time"
-                    : "Full Time",
+            employmentType: normalizeEmploymentTypeForVoucher(
+                voucher.employmentType,
+            ),
             employmentArrangement: "Local Worker",
             minimumWorkingHours,
             monthlyPay:

--- a/services/payroll/update-voucher-pay-rates.ts
+++ b/services/payroll/update-voucher-pay-rates.ts
@@ -5,7 +5,10 @@ import { employmentTable } from "@/db/tables/employmentTable";
 import { payrollVoucherTable } from "@/db/tables/payrollVoucherTable";
 import {
     assertDraftPayrollVoucher,
+    normalizeEmploymentTypeForVoucher,
     persistDraftPayrollVoucherUpdate,
+    validatePayrollAndVoucherIds,
+    type VoucherMutationResult,
 } from "@/services/payroll/_shared/voucher-update-pipeline";
 import { buildDraftPayrollVoucherValues } from "@/services/payroll/draft-payroll-voucher-values";
 
@@ -15,21 +18,7 @@ export type VoucherPayRateField =
     | "restDayRate"
     | "minimumWorkingHours";
 
-export type UpdateVoucherPayRateResult =
-    | {
-          success: true;
-          payrollId: string;
-          voucherId: string;
-      }
-    | {
-          success: false;
-          code:
-              | "VALIDATION_ERROR"
-              | "NOT_FOUND"
-              | "CONFLICT"
-              | "INTERNAL_ERROR";
-          error: string;
-      };
+export type UpdateVoucherPayRateResult = VoucherMutationResult;
 
 export async function updateVoucherPayRate(input: {
     payrollId: string;
@@ -37,15 +26,15 @@ export async function updateVoucherPayRate(input: {
     field: VoucherPayRateField;
     value: number | null;
 }): Promise<UpdateVoucherPayRateResult> {
-    const { payrollId, voucherId, field, value } = input;
-
-    if (!voucherId || !payrollId) {
-        return {
-            success: false,
-            code: "VALIDATION_ERROR",
-            error: "Missing voucherId or payrollId",
-        };
+    const identifiers = validatePayrollAndVoucherIds(
+        input.payrollId,
+        input.voucherId,
+    );
+    if (!identifiers.ok) {
+        return identifiers.result;
     }
+    const { payrollId, voucherId } = identifiers;
+    const { field, value } = input;
     if (
         !["monthlyPay", "hourlyRate", "restDayRate", "minimumWorkingHours"].includes(
             field,
@@ -153,10 +142,9 @@ export async function updateVoucherPayRate(input: {
 
     const voucherValues = buildDraftPayrollVoucherValues({
         employment: {
-            employmentType:
-                voucher.employmentType === "Part Time"
-                    ? "Part Time"
-                    : "Full Time",
+            employmentType: normalizeEmploymentTypeForVoucher(
+                voucher.employmentType,
+            ),
             employmentArrangement: (voucher.employmentArrangement ??
                 "Local Worker") as Em["employmentArrangement"],
             minimumWorkingHours,


### PR DESCRIPTION
Draft PR: refactor from clone-dedupe Pattern A batch.

## Summary
- Shared draft payroll voucher refresh + advance repayment window filter reused by settle/revert and revert preview.
- Save-payroll: `fetchWorkerWithEmployment` + `computeDraftVoucherInputs`.
- Worker form: segmented two-choice toggles component.
- Selection dialog tests aligned with settle vs ZIP flows.

## Verify
- `npx vitest run --pool=forks --maxWorkers=4`


Made with [Cursor](https://cursor.com)